### PR TITLE
Enhance Docker build caching and update documentation

### DIFF
--- a/.github/workflows/build-base-images-task.yml
+++ b/.github/workflows/build-base-images-task.yml
@@ -19,10 +19,12 @@ jobs:
         base:
           - name: nx-base
             dockerfile: Docker/NxBase.Dockerfile
+            cache_tag: docker.io/ptr727/nx-base:ubuntu-noble
             tags: |
               docker.io/ptr727/nx-base:ubuntu-noble
           - name: nx-base-lsio
             dockerfile: Docker/NxBase-LSIO.Dockerfile
+            cache_tag: docker.io/ptr727/nx-base-lsio:ubuntu-noble
             tags: |
               docker.io/ptr727/nx-base-lsio:ubuntu-noble
 
@@ -57,7 +59,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ matrix.base.tags }}
           cache-from: |
-            type=registry,ref=${{ matrix.base.tags }}
+            type=registry,ref=${{ matrix.base.cache_tag }}
             type=gha,scope=develop-base-${{ matrix.base.name }}
             type=gha,scope=main-base-${{ matrix.base.name }}
             ${{ github.event.pull_request && format('type=gha,scope=pr-base-{0}-{1}', github.event.pull_request.number, matrix.base.name) || '' }}


### PR DESCRIPTION
Improve Docker build caching by adding `cache_tag` to base image definitions and updating the cache logic for feature branches. Additionally, update the Docker Hub README and GitHub Copilot guidance for better clarity and usability. Fix syntax issues in the jq command for generating Docker Hub repositories.