### PR TITLE
Fix non-LSIO currentOsVariantOverride hidden by etc bind mount

### DIFF
--- a/CreateMatrix/Dockerfile.cs
+++ b/CreateMatrix/Dockerfile.cs
@@ -316,11 +316,11 @@ internal static class DockerFile
                 # Only allow sudo no password access to the root-tool
                 RUN echo "${COMPANY_NAME} ALL = NOPASSWD: /opt/${COMPANY_NAME}/mediaserver/bin/root-tool" > /etc/sudoers.d/${COMPANY_NAME}
 
-                # Tell mediaserver it is running under Docker so it reports its OS variant correctly
-                # https://github.com/networkoptix/nxvms-docker/commit/54bbd16
-                RUN echo "currentOsVariantOverride=docker" >> /opt/${COMPANY_NAME}/mediaserver/etc/mediaserver.conf
-
                 """;
+            // Note: for non-LSIO, currentOsVariantOverride=docker is injected at runtime by
+            // Docker/entrypoint.sh, because the recommended non-LSIO setup bind-mounts
+            // /opt/${COMPANY_NAME}/mediaserver/etc from the host, which would hide any
+            // build-time edit. Both variants now use runtime injection for the same reason.
         }
 
         return install;

--- a/Docker/DWSpectrum.Dockerfile
+++ b/Docker/DWSpectrum.Dockerfile
@@ -101,10 +101,6 @@ RUN apt-get update \
 # Only allow sudo no password access to the root-tool
 RUN echo "${COMPANY_NAME} ALL = NOPASSWD: /opt/${COMPANY_NAME}/mediaserver/bin/root-tool" > /etc/sudoers.d/${COMPANY_NAME}
 
-# Tell mediaserver it is running under Docker so it reports its OS variant correctly
-# https://github.com/networkoptix/nxvms-docker/commit/54bbd16
-RUN echo "currentOsVariantOverride=docker" >> /opt/${COMPANY_NAME}/mediaserver/etc/mediaserver.conf
-
 # Copy the entrypoint.sh launch script
 # entrypoint.sh will run the mediaserver and root-tool
 COPY entrypoint.sh /opt/entrypoint.sh

--- a/Docker/NxGo.Dockerfile
+++ b/Docker/NxGo.Dockerfile
@@ -101,10 +101,6 @@ RUN apt-get update \
 # Only allow sudo no password access to the root-tool
 RUN echo "${COMPANY_NAME} ALL = NOPASSWD: /opt/${COMPANY_NAME}/mediaserver/bin/root-tool" > /etc/sudoers.d/${COMPANY_NAME}
 
-# Tell mediaserver it is running under Docker so it reports its OS variant correctly
-# https://github.com/networkoptix/nxvms-docker/commit/54bbd16
-RUN echo "currentOsVariantOverride=docker" >> /opt/${COMPANY_NAME}/mediaserver/etc/mediaserver.conf
-
 # Copy the entrypoint.sh launch script
 # entrypoint.sh will run the mediaserver and root-tool
 COPY entrypoint.sh /opt/entrypoint.sh

--- a/Docker/NxMeta.Dockerfile
+++ b/Docker/NxMeta.Dockerfile
@@ -101,10 +101,6 @@ RUN apt-get update \
 # Only allow sudo no password access to the root-tool
 RUN echo "${COMPANY_NAME} ALL = NOPASSWD: /opt/${COMPANY_NAME}/mediaserver/bin/root-tool" > /etc/sudoers.d/${COMPANY_NAME}
 
-# Tell mediaserver it is running under Docker so it reports its OS variant correctly
-# https://github.com/networkoptix/nxvms-docker/commit/54bbd16
-RUN echo "currentOsVariantOverride=docker" >> /opt/${COMPANY_NAME}/mediaserver/etc/mediaserver.conf
-
 # Copy the entrypoint.sh launch script
 # entrypoint.sh will run the mediaserver and root-tool
 COPY entrypoint.sh /opt/entrypoint.sh

--- a/Docker/NxWitness.Dockerfile
+++ b/Docker/NxWitness.Dockerfile
@@ -101,10 +101,6 @@ RUN apt-get update \
 # Only allow sudo no password access to the root-tool
 RUN echo "${COMPANY_NAME} ALL = NOPASSWD: /opt/${COMPANY_NAME}/mediaserver/bin/root-tool" > /etc/sudoers.d/${COMPANY_NAME}
 
-# Tell mediaserver it is running under Docker so it reports its OS variant correctly
-# https://github.com/networkoptix/nxvms-docker/commit/54bbd16
-RUN echo "currentOsVariantOverride=docker" >> /opt/${COMPANY_NAME}/mediaserver/etc/mediaserver.conf
-
 # Copy the entrypoint.sh launch script
 # entrypoint.sh will run the mediaserver and root-tool
 COPY entrypoint.sh /opt/entrypoint.sh

--- a/Docker/WisenetWAVE.Dockerfile
+++ b/Docker/WisenetWAVE.Dockerfile
@@ -101,10 +101,6 @@ RUN apt-get update \
 # Only allow sudo no password access to the root-tool
 RUN echo "${COMPANY_NAME} ALL = NOPASSWD: /opt/${COMPANY_NAME}/mediaserver/bin/root-tool" > /etc/sudoers.d/${COMPANY_NAME}
 
-# Tell mediaserver it is running under Docker so it reports its OS variant correctly
-# https://github.com/networkoptix/nxvms-docker/commit/54bbd16
-RUN echo "currentOsVariantOverride=docker" >> /opt/${COMPANY_NAME}/mediaserver/etc/mediaserver.conf
-
 # Copy the entrypoint.sh launch script
 # entrypoint.sh will run the mediaserver and root-tool
 COPY entrypoint.sh /opt/entrypoint.sh

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -4,6 +4,18 @@
 echo "Launching root-tool"
 sudo /opt/${COMPANY_NAME}/mediaserver/bin/root-tool &
 
+# Tell mediaserver it is running under Docker so it reports its OS variant correctly
+# https://github.com/networkoptix/nxvms-docker/commit/54bbd16
+# Inject at runtime rather than build time because the recommended non-LSIO setup
+# bind-mounts /opt/${COMPANY_NAME}/mediaserver/etc from the host, which hides any
+# build-time edit. Idempotent so subsequent starts don't duplicate the line.
+MEDIASERVER_CONF="/opt/${COMPANY_NAME}/mediaserver/etc/mediaserver.conf"
+if ! grep -q "^currentOsVariantOverride=docker" "${MEDIASERVER_CONF}" 2>/dev/null
+then
+    echo "Adding currentOsVariantOverride=docker to ${MEDIASERVER_CONF}"
+    echo "currentOsVariantOverride=docker" >> "${MEDIASERVER_CONF}"
+fi
+
 # Launch the mediaserver using exec so it receives shutdown commands
 echo "Launching mediaserver"
 exec /opt/${COMPANY_NAME}/mediaserver/bin/mediaserver -e


### PR DESCRIPTION
## Summary

Follow-up to #380. Copilot review on PR #381 (develop → main sync) caught that the non-LSIO build-time RUN from #380 is shadowed by the README's recommended bind-mount of `/opt/${COMPANY_NAME}/mediaserver/etc` — the host's etc directory hides the image's pre-edited `mediaserver.conf` at runtime.

Same shape as the LSIO bug Copilot caught in PR #380's round 1, just for the other variant. Fix mirrors the LSIO approach: drop the build-time RUN and inject idempotently at container start.

## Changes

- [`CreateMatrix/Dockerfile.cs`](CreateMatrix/Dockerfile.cs) — remove the build-time RUN from the non-LSIO `else` branch; add a comment pointing readers to the runtime equivalent.
- [`Docker/entrypoint.sh`](Docker/entrypoint.sh) — add the same idempotent `grep -q && echo >>` pattern used in [`init-nx-relocate/run`](Docker/s6-overlay/s6-rc.d/init-nx-relocate/run) for LSIO. Runs after root-tool launch and before `exec mediaserver`.
- 5 non-LSIO product Dockerfiles regenerate to drop the RUN. LSIO Dockerfiles unchanged.

After this, both variants follow the same pattern: build is mediaserver-only; mediaserver.conf injection happens at runtime in the variant-appropriate init path.

## Test plan

- [x] `dotnet test CreateMatrixTests/CreateMatrixTests.csproj` — 16/16 pass.
- [x] `grep -c currentOsVariantOverride=docker Docker/*.Dockerfile` — 0/0 (all moved to runtime scripts).
- [ ] Build a non-LSIO image, run with a bind-mounted empty etc dir, then `cat <bound-etc>/mediaserver.conf` shows the line.