### PR TITLE
Loosen currentOsVariantOverride idempotence check

### DIFF
--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -8,9 +8,11 @@ sudo /opt/${COMPANY_NAME}/mediaserver/bin/root-tool &
 # https://github.com/networkoptix/nxvms-docker/commit/54bbd16
 # Inject at runtime rather than build time because the recommended non-LSIO setup
 # bind-mounts /opt/${COMPANY_NAME}/mediaserver/etc from the host, which hides any
-# build-time edit. Idempotent so subsequent starts don't duplicate the line.
+# build-time edit. Check for any `currentOsVariantOverride=` key (regardless of
+# value) so we never duplicate the line on subsequent starts and never override
+# a value the user explicitly set themselves.
 MEDIASERVER_CONF="/opt/${COMPANY_NAME}/mediaserver/etc/mediaserver.conf"
-if ! grep -q "^currentOsVariantOverride=docker" "${MEDIASERVER_CONF}" 2>/dev/null
+if ! grep -q "^currentOsVariantOverride=" "${MEDIASERVER_CONF}" 2>/dev/null
 then
     echo "Adding currentOsVariantOverride=docker to ${MEDIASERVER_CONF}"
     echo "currentOsVariantOverride=docker" >> "${MEDIASERVER_CONF}"

--- a/Docker/s6-overlay/s6-rc.d/init-nx-relocate/run
+++ b/Docker/s6-overlay/s6-rc.d/init-nx-relocate/run
@@ -73,8 +73,11 @@ fi
 # https://github.com/networkoptix/nxvms-docker/commit/54bbd16
 # Inject at runtime rather than build time because the etc directory above is replaced
 # by a symlink to /config/etc on first start, which would erase any build-time edit.
+# Check for any `currentOsVariantOverride=` key (regardless of value) so we never
+# duplicate the line on subsequent starts and never override a value the user
+# explicitly set themselves.
 MEDIASERVER_CONF="/config/etc/mediaserver.conf"
-if ! grep -q "^currentOsVariantOverride=docker" "${MEDIASERVER_CONF}" 2>/dev/null
+if ! grep -q "^currentOsVariantOverride=" "${MEDIASERVER_CONF}" 2>/dev/null
 then
     echo "Adding currentOsVariantOverride=docker to ${MEDIASERVER_CONF}"
     echo "currentOsVariantOverride=docker" >> "${MEDIASERVER_CONF}"


### PR DESCRIPTION
## Summary

Copilot review on PR #381 round 2 flagged two related edge cases in the runtime injection added by #380 / #382:

1. **False positive on prefix match** — `grep -q "^currentOsVariantOverride=docker"` matches `currentOsVariantOverride=docker2` (or anything starting with `docker`).
2. **No upgrade path on existing different value** — if the user had previously set `currentOsVariantOverride=<other>`, the check fails and we append a *second* line for the same key, leaving precedence up to the parser.

## Fix

In both [`Docker/entrypoint.sh`](Docker/entrypoint.sh) (non-LSIO) and [`Docker/s6-overlay/s6-rc.d/init-nx-relocate/run`](Docker/s6-overlay/s6-rc.d/init-nx-relocate/run) (LSIO), match the **key alone** — `^currentOsVariantOverride=` — and only append when the key is absent. This:

- Avoids prefix-match false positives.
- Never produces duplicate lines.
- Respects a user's explicit setting (don't override what they typed).

## Test plan

- [x] `dotnet test CreateMatrixTests/CreateMatrixTests.csproj` — 16/16 pass.
- [ ] CI matrix passes.