### PR TITLE
Guard conf write and address Copilot copy-edits

### DIFF
--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -16,7 +16,7 @@ sudo /opt/${COMPANY_NAME}/mediaserver/bin/root-tool &
 MEDIASERVER_CONF="/opt/${COMPANY_NAME}/mediaserver/etc/mediaserver.conf"
 if ! grep -q "^currentOsVariantOverride=" "${MEDIASERVER_CONF}" 2>/dev/null
 then
-    if echo "currentOsVariantOverride=docker" >> "${MEDIASERVER_CONF}" 2>/dev/null
+    if echo "currentOsVariantOverride=docker" >> "${MEDIASERVER_CONF}"
     then
         echo "Added currentOsVariantOverride=docker to ${MEDIASERVER_CONF}"
     else

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -10,12 +10,18 @@ sudo /opt/${COMPANY_NAME}/mediaserver/bin/root-tool &
 # bind-mounts /opt/${COMPANY_NAME}/mediaserver/etc from the host, which hides any
 # build-time edit. Check for any `currentOsVariantOverride=` key (regardless of
 # value) so we never duplicate the line on subsequent starts and never override
-# a value the user explicitly set themselves.
+# a value the user explicitly set themselves. Entrypoint runs as the unprivileged
+# ${COMPANY_NAME} user, so the bind-mounted etc directory must be writable by
+# that user (same requirement as mediaserver itself writes its own conf).
 MEDIASERVER_CONF="/opt/${COMPANY_NAME}/mediaserver/etc/mediaserver.conf"
 if ! grep -q "^currentOsVariantOverride=" "${MEDIASERVER_CONF}" 2>/dev/null
 then
-    echo "Adding currentOsVariantOverride=docker to ${MEDIASERVER_CONF}"
-    echo "currentOsVariantOverride=docker" >> "${MEDIASERVER_CONF}"
+    if echo "currentOsVariantOverride=docker" >> "${MEDIASERVER_CONF}" 2>/dev/null
+    then
+        echo "Added currentOsVariantOverride=docker to ${MEDIASERVER_CONF}"
+    else
+        echo "Warning: failed to write ${MEDIASERVER_CONF} — check that the bind-mounted etc directory is writable by user ${COMPANY_NAME}" >&2
+    fi
 fi
 
 # Launch the mediaserver using exec so it receives shutdown commands

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ services:
       - test_nxwitness-lsio_backup:/backup
       - test_nxwitness-lsio_analytics:/analytics
     tmpfs:
-      # Keep mediaserver's unix socket and tmp files in RAM
+      # Keep mediaserver's Unix socket and tmp files in RAM
       - /tmp:size=1g,mode=1777
 ```
 
@@ -107,7 +107,7 @@ services:
       - ${NVR_DIR}/media:/media # ssdpool/nvr-media
       - ${NVR_DIR}/backup:/backup # hddpool/nvr-backup
       - ${NVR_DIR}/analytics:/analytics # ssdpool/nvr-analytics
-    tmpfs: # Keep mediaserver's unix socket and tmp files in RAM
+    tmpfs: # Keep mediaserver's Unix socket and tmp files in RAM
       - /tmp:size=1g,mode=1777
     networks:
       public_network:
@@ -369,7 +369,7 @@ services:
       - /mnt/nxwitness/config:/config
       - /mnt/nxwitness/media:/media
     tmpfs:
-      # Keep mediaserver's unix socket and tmp files in RAM
+      # Keep mediaserver's Unix socket and tmp files in RAM
       - /tmp:size=1g,mode=1777
 ```
 
@@ -388,7 +388,7 @@ services:
       - /mnt/nxwitness/config/var:/opt/networkoptix/mediaserver/var
       - /mnt/nxwitness/media:/media
     tmpfs:
-      # Keep mediaserver's unix socket and tmp files in RAM
+      # Keep mediaserver's Unix socket and tmp files in RAM
       - /tmp:size=1g,mode=1777
 ```
 
@@ -463,7 +463,7 @@ services:
   - Camera recording license keys are activated and bound to hardware attributes of the host server collected by the `root-tool` that is required to run as `root`.
   - Requiring the `root-tool` to run as root overly complicates running the `mediaserver` as a non-root user, and requires the container to run using `host` networking to not break the hardware license checks.
   - Docker containers are supposed to be portable, and moving containers between hosts will break license activation.
-  - Nx's own [`nxvms-docker`][nxgithubcompose-link] reference image [recently disabled `root-tool`](https://github.com/networkoptix/nxvms-docker/commit/4285f93) by setting `ignoreRootTool=true` in `mediaserver.conf` and dropping their separate `root-tool` container. This trades hardware-ID license enforcement for a simpler unprivileged container. NxWitness does **not** follow this change — licensed deployments would lose activation — and will revisit only if Nx publishes a clearer official position on Docker licensing without `root-tool`.
+  - Nx's own [`nxvms-docker`][nxgithubcompose-link] reference image [disabled `root-tool` in late 2025](https://github.com/networkoptix/nxvms-docker/commit/4285f93) by setting `ignoreRootTool=true` in `mediaserver.conf` and dropping their separate `root-tool` container. This trades hardware-ID license enforcement for a simpler unprivileged container. NxWitness does **not** follow this change — licensed deployments would lose activation — and will revisit only if Nx publishes a clearer official position on Docker licensing without `root-tool`.
   - Nx to fix: Associate licenses with the [Cloud Account][nxcloud-link] not the local hardware.
 - Storage Management:
   - The mediaserver attempts to automatically decide what storage to use.


### PR DESCRIPTION
## Summary

Round-3 follow-up from Copilot's review on PR #381 (develop -> main sync). Six findings; this PR addresses the substantive ones; the seventh (PR #381's test plan referencing a build-time verification that no longer applies) will be fixed by editing #381's description directly.

## Changes

- [`Docker/entrypoint.sh`](Docker/entrypoint.sh) — guard the `mediaserver.conf` append. The entrypoint runs as the unprivileged `${COMPANY_NAME}` user, so the bind-mounted etc directory must be writable by that user. Previously the `>>` would silently error if not writable. Now wraps the redirect in a conditional and logs a clear stderr warning identifying the required ownership.
- [`README.md`](README.md) (4 lines) — capitalize "Unix" in "Unix socket" tmpfs comments. Proper-noun consistency.
- [`README.md`](README.md) (1 line) — replace "recently disabled `root-tool`" with "disabled `root-tool` in late 2025". Less time-relative, ages better.

## Test plan

- [x] `dotnet test CreateMatrixTests/CreateMatrixTests.csproj` — 16/16 pass.
- [ ] CI matrix passes.