### PR TITLE
Guard LSIO conf append for parity with non-LSIO

### DIFF
--- a/Docker/s6-overlay/s6-rc.d/init-nx-relocate/run
+++ b/Docker/s6-overlay/s6-rc.d/init-nx-relocate/run
@@ -75,11 +75,17 @@ fi
 # by a symlink to /config/etc on first start, which would erase any build-time edit.
 # Check for any `currentOsVariantOverride=` key (regardless of value) so we never
 # duplicate the line on subsequent starts and never override a value the user
-# explicitly set themselves.
+# explicitly set themselves. Same defensive write pattern as Docker/entrypoint.sh:
+# this script runs as root, but the underlying /config mount may still be on a
+# read-only filesystem, so guard the append and log a clear warning if it fails.
 MEDIASERVER_CONF="/config/etc/mediaserver.conf"
 if ! grep -q "^currentOsVariantOverride=" "${MEDIASERVER_CONF}" 2>/dev/null
 then
-    echo "Adding currentOsVariantOverride=docker to ${MEDIASERVER_CONF}"
-    echo "currentOsVariantOverride=docker" >> "${MEDIASERVER_CONF}"
-    chown ${COMPANY_NAME}:${COMPANY_NAME} "${MEDIASERVER_CONF}"
+    if echo "currentOsVariantOverride=docker" >> "${MEDIASERVER_CONF}"
+    then
+        echo "Added currentOsVariantOverride=docker to ${MEDIASERVER_CONF}"
+        chown ${COMPANY_NAME}:${COMPANY_NAME} "${MEDIASERVER_CONF}"
+    else
+        echo "Warning: failed to write ${MEDIASERVER_CONF} — check that the /config mount is writable" >&2
+    fi
 fi


### PR DESCRIPTION
## Summary

Round-4 follow-up from Copilot's review on PR #381. The LSIO init script ([`init-nx-relocate/run`](Docker/s6-overlay/s6-rc.d/init-nx-relocate/run)) appended to `/config/etc/mediaserver.conf` without checking the result. The script runs as root, but the underlying `/config` mount can be on a read-only filesystem or otherwise rejected, so a silent failure would leave mediaserver running without the OS variant override.

## Fix

Apply the same defensive pattern non-LSIO already uses in [`Docker/entrypoint.sh`](Docker/entrypoint.sh) (added in #384): wrap the append in an `if`, log a clear stderr warning on failure, and only `chown` on successful write. Both variants now log "Added" on success and "Warning: failed to write" on failure with a hint about what to check.

## Test plan

- [x] `dotnet test CreateMatrixTests/CreateMatrixTests.csproj` — 16/16 pass.
- [ ] CI matrix passes.