### PR TITLE
Document Traefik nxmeta-web rationale in compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ services:
       stack_network:
     labels:
       - traefik.enable=true # Traefik SSL proxy
+      # The container is multi-homed: bare `nxmeta` resolves to the
+      # dedicated macvlan IP above (direct), while `nxmeta-web` is a
+      # CNAME pointing at Traefik for SSL termination. Traefik only
+      # handles the `-web` hostname; the bare hostname bypasses it.
       - traefik.http.routers.nxmeta.rule=HostRegexp(`^nxmeta-web${DOMAIN_REGEX}$$`)
       - traefik.http.services.nxmeta.loadbalancer.server.scheme=https
       - traefik.http.services.nxmeta.loadbalancer.server.port=7001

--- a/README.md
+++ b/README.md
@@ -117,10 +117,12 @@ services:
       stack_network:
     labels:
       - traefik.enable=true # Traefik SSL proxy
-      # The container is multi-homed: bare `nxmeta` resolves to the
-      # dedicated macvlan IP above (direct), while `nxmeta-web` is a
-      # CNAME pointing at Traefik for SSL termination. Traefik only
-      # handles the `-web` hostname; the bare hostname bypasses it.
+      # Two-hostname pattern (DNS records configured externally, e.g.
+      # in your LAN DNS or hosts file): an A/AAAA `nxmeta -> ${NXMETA_IP}`
+      # points at the dedicated macvlan IP above for direct access,
+      # and a CNAME `nxmeta-web -> <traefik-host>` fronts the service
+      # with SSL termination. Traefik routes only the `-web` hostname;
+      # the bare hostname bypasses Traefik entirely.
       - traefik.http.routers.nxmeta.rule=HostRegexp(`^nxmeta-web${DOMAIN_REGEX}$$`)
       - traefik.http.services.nxmeta.loadbalancer.server.scheme=https
       - traefik.http.services.nxmeta.loadbalancer.server.port=7001


### PR DESCRIPTION
## Summary

Copilot flagged on PR #381 ([round-5](https://github.com/ptr727/NxWitness/pull/381#discussion_r3299207565) and [round-6](https://github.com/ptr727/NxWitness/pull/381#discussion_r3299221130)) that the production compose example uses service/hostname `nxmeta` but the Traefik `HostRegexp` matches `^nxmeta-web...`. The reviewer's concern was that the example would be unreachable through Traefik.

The mismatch is intentional. The container is multi-homed:

- **Bare `nxmeta`** resolves to the dedicated macvlan IP set via `${NXMETA_IP}` / `${NXMETA_MAC}` in the compose, used for direct access.
- **`nxmeta-web`** is a CNAME pointing at the Traefik host for SSL termination. Only the `-web` hostname is fronted by Traefik; the bare hostname bypasses it.

This is the real-world pattern from the user's homelab. Without the inline rationale, future readers (and future automated reviews) hit the same question.

## Change

Four lines of comment in [`README.md`](README.md) inside the Traefik labels block.

## Test plan

- [x] Markdown rendering checked — comment lines render as part of the YAML fenced block.
- [ ] CI matrix passes.