### PR TITLE
Make chown best-effort in LSIO init-nx-relocate

### DIFF
--- a/Docker/s6-overlay/s6-rc.d/init-nx-relocate/run
+++ b/Docker/s6-overlay/s6-rc.d/init-nx-relocate/run
@@ -84,7 +84,14 @@ then
     if echo "currentOsVariantOverride=docker" >> "${MEDIASERVER_CONF}"
     then
         echo "Added currentOsVariantOverride=docker to ${MEDIASERVER_CONF}"
-        chown ${COMPANY_NAME}:${COMPANY_NAME} "${MEDIASERVER_CONF}"
+        # Best-effort chown: /config may be on a filesystem that doesn't
+        # support ownership changes (e.g., some SMB/NFS/Windows-backed
+        # mounts), and a non-zero exit from chown would fail this oneshot
+        # service even though the write succeeded.
+        if ! chown ${COMPANY_NAME}:${COMPANY_NAME} "${MEDIASERVER_CONF}"
+        then
+            echo "Warning: failed to chown ${MEDIASERVER_CONF} — continuing (filesystem may not support ownership changes)" >&2
+        fi
     else
         echo "Warning: failed to write ${MEDIASERVER_CONF} — check that the /config mount is writable" >&2
     fi


### PR DESCRIPTION
## Summary

Copilot flagged on PR #381 (round-5 & round-6) that the `chown` added by #385 sits at the end of the success path in the LSIO init script. Because `init-nx-relocate` is an s6-rc **oneshot** service, a non-zero exit from its last command fails the service and breaks container init — even though the actual conf write succeeded. Filesystems that don't support ownership changes (SMB/NFS/Windows-backed) trigger this.

## Fix

Wrap the `chown` in an `if`-guard. On failure, log a clear stderr warning ("filesystem may not support ownership changes — continuing") and fall through; the outer `fi` always evaluates to 0, so the script exits cleanly. The actual conf-write outcome still drives the user-facing success/failure messaging.

## Test plan

- [x] `dotnet test CreateMatrixTests/CreateMatrixTests.csproj` — 16/16 pass.
- [ ] CI matrix passes.
- [ ] Manual: mount a `/config` volume backed by an exFAT or similar non-chown filesystem, start the LSIO container, confirm the s6 oneshot completes (container reaches running state, mediaserver launches) and the warning appears in container logs.