### PR TITLE
[CI TEST - do not merge] non-image change

### DIFF
--- a/ci-smoke-test-noimage.md
+++ b/ci-smoke-test-noimage.md
@@ -1,0 +1,3 @@
+# CI smoke-test (throwaway, do not merge)
+
+Validates that a non-image PR skips the Docker smoke build.


### PR DESCRIPTION
Throwaway PR to validate the new PR pipeline: a non-image change should SKIP the Docker smoke build and run unit tests only. Will be closed without merging.