### PR TITLE
Refine workspace/linting docs (scope .vscode statement, drop overclaim)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,7 +43,7 @@ This repository builds and publishes Docker images for Network Optix VMS product
 - Pull requests run unit tests and style checks, plus a fast smoke build (NxMeta and NxMeta-LSIO, amd64 only, no push) that runs only when image files change -- not the full matrix.
 - Publishing is schedule/manual only via `publish-release.yml`, which builds the base images once and then publishes the full matrix for both the `main` and `develop` branches in a single run.
 - Merges to `main`/`develop` do not publish; auto-merged Dependabot and codegen PRs are picked up by the next scheduled publish. Do not reintroduce push-triggered publishing or full-matrix PR builds.
-- Structured files are linted in-editor via the extensions recommended in the workspace file `NxWitness.code-workspace` (C#, Markdown, Docker, GitHub Actions, spelling) rather than a CI lint job; lint changed files before pushing, and run `actionlint` for deeper workflow checks. VS Code customizations belong in the workspace file, not under `.vscode/`. See AGENTS.md.
+- Structured files are linted in-editor via the extensions recommended in the workspace file `NxWitness.code-workspace` (C#, Markdown, Docker, GitHub Actions, spelling) rather than a CI lint job; lint changed files before pushing, and run `actionlint` for deeper workflow checks. Editor settings, extension recommendations, and spell-check words belong in the workspace file (not `.vscode/`). See AGENTS.md.
 
 ## What to Keep in Sync
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,8 @@ For comprehensive coding and formatting standards, follow:
 
 ### Workspace and linting
 
-- VS Code customizations (settings, extension recommendations, spell-check words) live in the workspace file `NxWitness.code-workspace`, not under `.vscode/`. Add new editor settings or recommended extensions there. Open the workspace file in VS Code (not the folder) so those settings and recommendations apply.
-- Every structured file type is linted in-editor via the extensions recommended in `NxWitness.code-workspace` (C#, Markdown, Dockerfiles/Compose, GitHub Actions, spelling, etc.); there is no separate CI lint job. Lint changed files and clear reported problems before pushing.
+- VS Code settings, extension recommendations, and spell-check words live in the workspace file `NxWitness.code-workspace`; add new editor settings or recommended extensions there rather than in `.vscode/`. (Build/debug tasks still live in `.vscode/tasks.json` and `.vscode/launch.json`.) Open the workspace file in VS Code (not the folder) so its settings and recommendations apply.
+- Linting is editor-only (no CI lint job); the extensions recommended in `NxWitness.code-workspace` cover the project's structured files: C# (Roslyn + CSharpier), Markdown, Dockerfiles/Compose, GitHub Actions workflows, and spelling. Lint changed files and clear reported problems before pushing.
 - For workflow files, the GitHub Actions extension covers schema/expression checks in-editor; run the `actionlint` CLI for deeper checks (including shellcheck on `run:` steps).
 
 ## Image Architecture


### PR DESCRIPTION
Follow-up to #402, addressing two Copilot doc comments on #403:

- **AGENTS.md** no longer claims "every structured file type" is linted (which over-implied generic YAML coverage now that `.vscode/extensions.json`/`redhat.vscode-yaml` is gone); it lists the extensions' actual coverage. The workspace convention is scoped to settings/extension recommendations/spell-check words, and notes that build/debug tasks still live in `.vscode/tasks.json` / `launch.json`.
- **copilot-instructions.md** scopes the "belongs in the workspace, not `.vscode/`" statement the same way, so it no longer contradicts the tracked `.vscode/tasks.json` referenced elsewhere in the doc.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)