### PR TITLE
Skip duplicate GitHub release and pin tag to built commit SHA

### DIFF
--- a/.github/workflows/get-version-task.yml
+++ b/.github/workflows/get-version-task.yml
@@ -16,6 +16,11 @@ on:
         value: ${{ jobs.get-version.outputs.AssemblyFileVersion }}
       AssemblyInformationalVersion:
         value: ${{ jobs.get-version.outputs.AssemblyInformationalVersion }}
+      # Full SHA of the commit NBGV computed the version from. Used to pin the
+      # GitHub release tag to the exact built commit (immutable) rather than a
+      # moving branch ref.
+      GitCommitId:
+        value: ${{ jobs.get-version.outputs.GitCommitId }}
 
 jobs:
 
@@ -27,6 +32,7 @@ jobs:
       AssemblyVersion: ${{ steps.nbgv.outputs.AssemblyVersion }}
       AssemblyFileVersion: ${{ steps.nbgv.outputs.AssemblyFileVersion }}
       AssemblyInformationalVersion: ${{ steps.nbgv.outputs.AssemblyInformationalVersion }}
+      GitCommitId: ${{ steps.nbgv.outputs.GitCommitId }}
 
     steps:
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -81,14 +81,36 @@ jobs:
         with:
           ref: main
 
+      # The weekly schedule re-runs even when main has no new commits, so NBGV
+      # can produce a SemVer2 that was already released. GitHub release creation
+      # has no built-in skip-duplicate, and re-publishing an unchanged version
+      # churns the release (and can fail re-uploading existing assets), so skip
+      # the release step when a release for this tag already exists.
+      - name: Check for existing release step
+        id: release-exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.get-version.outputs.SemVer2 }}
+        run: |
+          set -euo pipefail
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Release $TAG already exists; skipping release creation (no-op republish)."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create GitHub release step
+        if: ${{ steps.release-exists.outputs.exists == 'false' }}
         uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           tag_name: ${{ needs.get-version.outputs.SemVer2 }}
-          # Pin the tag to main's HEAD so a dispatch from another ref still
-          # tags the release on main, matching the main-pinned version/assets.
-          target_commitish: main
+          # Pin the tag to the exact commit NBGV versioned (main's HEAD at
+          # version-compute time, since get-version runs with ref: main) rather
+          # than the moving `main` ref — immutable, and consistent with the
+          # version/assets even if a commit lands on main mid-run.
+          target_commitish: ${{ needs.get-version.outputs.GitCommitId }}
           # This run's release represents the main publish.
           prerelease: false
           files: |

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -76,16 +76,21 @@ jobs:
 
     steps:
 
+      # Check out the exact commit NBGV versioned (not the moving `main` ref),
+      # so the uploaded release files come from the same commit the tag points
+      # at even if `main` advances mid-run.
       - name: Checkout code step
         uses: actions/checkout@v6
         with:
-          ref: main
+          ref: ${{ needs.get-version.outputs.GitCommitId }}
 
       # The weekly schedule re-runs even when main has no new commits, so NBGV
       # can produce a SemVer2 that was already released. GitHub release creation
       # has no built-in skip-duplicate, and re-publishing an unchanged version
       # churns the release (and can fail re-uploading existing assets), so skip
-      # the release step when a release for this tag already exists.
+      # the release step when a release for this tag already exists — but only
+      # on the schedule. A `workflow_dispatch` is always allowed through so a
+      # maintainer can re-run to repair a partially-created release.
       - name: Check for existing release step
         id: release-exists
         env:
@@ -101,7 +106,10 @@ jobs:
           fi
 
       - name: Create GitHub release step
-        if: ${{ steps.release-exists.outputs.exists == 'false' }}
+        # Skip only when the release already exists AND this is a scheduled
+        # run (the no-op weekly case). A manual `workflow_dispatch` always runs
+        # so it can repair/refresh an existing release for the same tag.
+        if: ${{ steps.release-exists.outputs.exists == 'false' || github.event_name == 'workflow_dispatch' }}
         uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true


### PR DESCRIPTION
Closes #407.

Two robustness fixes to the `github-release` job in `publish-release.yml`, ported from ptr727/ProjectTemplate#98.

## 1. Skip duplicate release on no-op weeks

The weekly schedule re-runs even when `main` has no new commits, so NBGV produces the **same `SemVer2`** and `softprops/action-gh-release` is asked to (re)create an existing release/tag — churning the release every week and risking failures re-uploading existing assets. Added a `Check for existing release` step (`gh release view "$SemVer2"`) that gates the release-creation step, so a no-op week is a true no-op.

## 2. Pin release tag to the built commit, not a moving ref

`target_commitish: main` is a **moving ref** — a commit landing on `main` mid-run could tag the release on a newer commit than the one built. Pinned it to NBGV's `GitCommitId` (the exact commit the version was computed from; `get-version` runs with `ref: main`). Added `GitCommitId` as a `get-version-task.yml` output.

Matches the existing file conventions (no new action pins introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)