### PR TITLE
Clarify release-skip log message for workflow_dispatch

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -96,11 +96,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.get-version.outputs.SemVer2 }}
+          EVENT: ${{ github.event_name }}
         run: |
           set -euo pipefail
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "Release $TAG already exists; skipping release creation (no-op republish)."
+            if [[ "$EVENT" == "workflow_dispatch" ]]; then
+              echo "Release $TAG already exists; workflow_dispatch will refresh it."
+            else
+              echo "Release $TAG already exists; skipping release creation (no-op republish)."
+            fi
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
Follow-up to #408 (Copilot review on #411): the "Check for existing release" step always logged "skipping release creation", but on `workflow_dispatch` the create step is allowed through (to repair a release), so the log was misleading. Make the message event-aware — it now says the dispatch will refresh the release instead of skipping.

Log-string only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)