### PR TITLE
Gate smoke build on test-release (back-port from PlexCleaner port)

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -62,7 +62,11 @@ jobs:
   # it to validate it still compiles (e.g. a Dependabot ubuntu:noble bump).
   smoke-build:
     name: Smoke build job
-    needs: [changes]
+    # Also gate on test-release: the smoke build builds Docker images, so don't
+    # spend it when the test job is already failing. A failed test-release
+    # leaves this job skipped (needs unsatisfied) and the aggregator blocks on
+    # the test-release failure directly.
+    needs: [changes, test-release]
     if: ${{ needs.changes.outputs.image == 'true' }}
     uses: ./.github/workflows/build-docker-task.yml
     secrets: inherit


### PR DESCRIPTION
Back-port from the PlexCleaner two-phase CI/CD port (ptr727/PlexCleaner#723), where this repo's patterns were audited for the same issues.

## Applied
- **Gate `smoke-build` on `test-release`** (`needs: [changes, test-release]`). The smoke build builds Docker images, so it shouldn't be spent when the test job is already failing; a failed `test-release` now leaves smoke-build skipped and the aggregator blocks on the test failure directly. Brings NxWitness in line with the sibling repos' PR workflows.

## Audited — already present in NxWitness (no change needed)
- `github-release` checks out NBGV `GitCommitId` and allows `workflow_dispatch` through the skip-if-exists gate (#408/#412).
- Docker `cache-to` already uses `ignore-error=true` (gha cache).
- `publish-release.yml` has **no `push` trigger**, so the no-op-push concurrency/badge issues don't arise.
- `publish-docker-readme-task` is called with an explicit `ref: main`, so it renders the README from the right branch.

## Noted for maintainer follow-up (NOT changed here)
- **`build-main` feeds the versioned release from a moving `ref: main`** while `get-version` resolves the release version separately — the same race fixed in PlexCleaner/ProjectTemplate by pinning leaf builds to `GitCommitId`. That pin is **not safe to apply here**: `build-docker-task` overloads `inputs.ref` as the image-matrix branch selector (`select(.Branch == $ref)`), so passing a SHA would match no rows. A proper fix decouples `ref` (checkout/version) from `branch` (matrix selector) — a small refactor better owned by the maintainer. (Low practical risk: requires a commit landing on `main` mid-publish.)

All workflows pass `actionlint`. Handed to the maintainer for merge.