### PR TITLE
Pin release Docker build to versioned commit (#414)

### DIFF
--- a/.github/workflows/build-docker-task.yml
+++ b/.github/workflows/build-docker-task.yml
@@ -15,17 +15,22 @@ on:
         required: false
         type: boolean
         default: false
-      # In smoke mode, restrict the build to this branch's rows (the PR
-      # base branch). Empty builds both branches' rows. Lets a PR onto
-      # develop smoke-test the develop images and a PR onto main the main
-      # images, without building the other branch.
-      smoke_branch:
+      # Logical branch whose Matrix.json rows to build/push and whose GHA
+      # cache scope to use. Decoupled from `ref` so `ref` can be pinned to an
+      # immutable commit (e.g. the publisher pins main to the versioned SHA)
+      # while this still selects the right branch's rows. Empty in smoke mode
+      # builds both branches' rows; the publisher passes main and develop so
+      # both branches' tags are produced from one scheduled run. Empty in a
+      # non-smoke build falls back to github.ref_name for the cache scope.
+      branch:
         required: false
         type: string
         default: ''
-      # Branch to check out and whose images to build/push. Empty uses the
-      # triggering ref (PR context). The publisher passes main and develop
-      # so both branches' tags are produced from one scheduled run.
+      # Immutable git ref to check out / version, decoupled from branch/tag
+      # selection (see `branch`). Empty uses the triggering ref (PR context).
+      # The publisher pins this to the exact versioned commit so the image's
+      # embedded version matches the GitHub release tag even if the branch
+      # advances mid-run.
       ref:
         required: false
         type: string
@@ -57,27 +62,26 @@ jobs:
         id: getmatrix
         env:
           SMOKE: ${{ inputs.smoke }}
-          SMOKE_BRANCH: ${{ inputs.smoke_branch }}
-          REF: ${{ inputs.ref }}
+          BRANCH: ${{ inputs.branch }}
         run: |
-          # $ref and $sb below are jq variables (passed via --arg), not shell
-          # variables, so they must stay single-quoted / unexpanded.
+          # $b below is a jq variable (passed via --arg), not a shell
+          # variable, so it must stay single-quoted / unexpanded.
           # shellcheck disable=SC2016
           if [[ "$SMOKE" == "true" ]]; then
             # One Ubuntu + one LSIO variant exercises the shared Dockerfile
             # build logic and the branch's build args; tags are irrelevant
-            # since smoke never pushes. Restrict to the PR base branch ($sb)
+            # since smoke never pushes. Restrict to the PR base branch ($b)
             # so a PR onto develop validates the develop rows and a PR onto
-            # main validates the main rows; empty $sb builds both branches.
-            FILTER='.Images |= (map(select((.Name == "NxMeta" or .Name == "NxMeta-LSIO") and ($sb == "" or .Branch == $sb))) | unique_by([.Name, .Branch]))'
-          elif [[ -n "$REF" ]]; then
+            # main validates the main rows; empty $b builds both branches.
+            FILTER='.Images |= (map(select((.Name == "NxMeta" or .Name == "NxMeta-LSIO") and ($b == "" or .Branch == $b))) | unique_by([.Name, .Branch]))'
+          elif [[ -n "$BRANCH" ]]; then
             # Publish: build only the rows targeting the branch being built
             # (avoids building the other branch's rows just to discard them).
-            FILTER='.Images |= map(select(.Branch == $ref))'
+            FILTER='.Images |= map(select(.Branch == $b))'
           else
             FILTER='.'
           fi
-          echo "matrix=$(jq --arg ref "$REF" --arg sb "$SMOKE_BRANCH" --compact-output "$FILTER" ./Make/Matrix.json)" >> "$GITHUB_OUTPUT"
+          echo "matrix=$(jq --arg b "$BRANCH" --compact-output "$FILTER" ./Make/Matrix.json)" >> "$GITHUB_OUTPUT"
 
   get-version:
     name: Get version information job
@@ -172,5 +176,5 @@ jobs:
             type=gha,scope=main-${{ matrix.images.Name }}
             ${{ github.event.pull_request && format('type=gha,scope=pr-{0}-{1}', github.event.pull_request.number, matrix.images.Name) || '' }}
           cache-to: |
-            ${{ inputs.push && format('type=gha,mode=min,scope={0}-{1},ignore-error=true', inputs.ref != '' && inputs.ref || github.ref_name, matrix.images.Name) || '' }}
+            ${{ inputs.push && format('type=gha,mode=min,scope={0}-{1},ignore-error=true', inputs.branch != '' && inputs.branch || github.ref_name, matrix.images.Name) || '' }}
             ${{ github.event.pull_request && !github.event.pull_request.head.repo.fork && format('type=gha,mode=min,scope=pr-{0}-{1},ignore-error=true', github.event.pull_request.number, matrix.images.Name) || '' }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -47,12 +47,17 @@ jobs:
 
   build-main:
     name: Build main images job
-    needs: [build-base]
+    needs: [get-version, build-base]
     uses: ./.github/workflows/build-docker-task.yml
     secrets: inherit
     with:
       push: true
-      ref: main
+      branch: main
+      # Pin to the exact commit get-version computed the release version from,
+      # not the moving `main` ref: this closes the race where a commit landing
+      # on main mid-run could make the pushed image's embedded version come
+      # from a newer commit than the GitHub release of the same SemVer2 tag.
+      ref: ${{ needs.get-version.outputs.GitCommitId }}
       build_base: false
 
   build-develop:
@@ -62,6 +67,10 @@ jobs:
     secrets: inherit
     with:
       push: true
+      # Develop only publishes the mutable :develop tag (no versioned GitHub
+      # release), so the moving ref can't cause a tag/release mismatch; no
+      # commit pin needed.
+      branch: develop
       ref: develop
       build_base: false
 

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -53,8 +53,9 @@ jobs:
   # scheduled publish-release.yml, so a smoke pass is fast PR feedback,
   # not a publish gate.
   #
-  # smoke_branch targets the PR base branch so a PR onto develop validates
-  # the develop image rows and a PR onto main validates the main rows.
+  # branch targets the PR base branch so a PR onto develop validates the
+  # develop image rows and a PR onto main validates the main rows. ref is
+  # left unset so checkout uses the PR ref being tested.
   #
   # build_base is only enabled when a base Dockerfile changed: the product
   # smoke build pulls the published base from Docker Hub, so building the
@@ -69,7 +70,7 @@ jobs:
     with:
       push: false
       smoke: true
-      smoke_branch: ${{ github.base_ref }}
+      branch: ${{ github.base_ref }}
       build_base: ${{ needs.changes.outputs.base == 'true' }}
 
   # TODO: Workaround for GitHub Actions not supporting status checks on conditional jobs


### PR DESCRIPTION
Resolves #414. Same change as #415 (the develop PR), targeting `main`.

## Problem

`publish-release.yml` built the versioned release from a **moving branch ref**: `build-main` called `build-docker-task.yml` with `ref: main`, which re-resolved its own version internally from the moving `main` ref. If a commit landed on `main` between `get-version` and `build-main` during the weekly scheduled publish, the pushed image's embedded version could come from a **newer commit** than the GitHub release of the same `SemVer2` tag — breaking release reproducibility.

The sibling-repo one-line fix (`ref: ${{ needs.get-version.outputs.GitCommitId }}`) couldn't be applied directly because `build-docker-task.yml` overloaded `inputs.ref` as both (1) the git checkout/version ref and (2) the `Make/Matrix.json` `.Branch` selector. A commit SHA would match no `.Branch` rows and build nothing.

## Fix

Decouple the two concerns, converging onto the canonical ProjectTemplate `branch`/`ref` split:

- **`build-docker-task.yml`** — replace `smoke_branch` with a single `branch` input driving the matrix `.Branch` filter and the GHA `cache-to` scope; `ref` is now purely the immutable checkout/version ref.
- **`publish-release.yml`** — `build-main` now `needs: [get-version, build-base]` and passes `branch: main` + `ref: ${{ needs.get-version.outputs.GitCommitId }}`, pinning the build to the exact versioned commit. `build-develop` passes `branch`/`ref: develop` (mutable `:develop` tag only, no versioned release → no pin needed).
- **`test-pull-request.yml`** — smoke caller passes `branch` instead of `smoke_branch`.

## Verification

- `actionlint` (Docker) on all three workflows: clean.
- Replicated all three `jq` filter branches against the real `Make/Matrix.json`: `branch=main`/`develop` each yield 18 single-branch rows; smoke yields the 2 `NxMeta`/`NxMeta-LSIO` rows per branch (4 when `branch` empty). All assertions passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)