### PR TITLE
Bump version to 2.13 for next prerelease cycle

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.12",
+  "version": "2.13",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
Isolated version bump establishing the develop-leads invariant: raises `develop`'s minor from `2.12` to `2.13` so develop's NBGV prereleases sort above main's last stable `2.12.x`. Per the versioning policy, kept as a standalone version-only change.