### PR TITLE
Fix version-forward regression creating duplicate versions

### DIFF
--- a/CreateMatrix/Dockerfile.cs
+++ b/CreateMatrix/Dockerfile.cs
@@ -18,8 +18,9 @@ internal static class DockerFile
         foreach (ProductInfo.ProductType productType in ProductInfo.GetProductTypes())
         {
             // Find the matching product
-            ProductInfo? productInfo = productList.Find(item => item.Product == productType);
-            ArgumentNullException.ThrowIfNull(productInfo);
+            ProductInfo productInfo =
+                productList.Find(item => item.Product == productType)
+                ?? throw new InvalidOperationException($"Product not found: {productType}");
 
             // Get the version for the label, not all releases include Beta and RC labels
             VersionInfo? versionInfo = productInfo.Versions.Find(item =>
@@ -38,7 +39,12 @@ internal static class DockerFile
                     item.Labels.Contains(VersionInfo.LabelType.Latest)
                 );
             }
-            ArgumentNullException.ThrowIfNull(versionInfo);
+            if (versionInfo == null)
+            {
+                throw new InvalidOperationException(
+                    $"{productType}: No version found for label {label} or Latest"
+                );
+            }
 
             // Create the standard Docker file
             string dockerFile = CreateDockerfile(productType, versionInfo, false);

--- a/CreateMatrix/ImageInfo.cs
+++ b/CreateMatrix/ImageInfo.cs
@@ -39,7 +39,8 @@ internal class ImageInfo
         Product = productType;
         Branch = branchType;
         Base = baseType;
-        Name = baseType == BaseType.Ubuntu ? productType.ToString() : $"{productType}-LSIO";
+        // The image name matches the Dockerfile name
+        Name = ProductInfo.GetDocker(productType, baseType == BaseType.LSIO);
     }
 
     private void AddArgs(VersionInfo versionInfo)

--- a/CreateMatrix/PackagesJsonSchema.cs
+++ b/CreateMatrix/PackagesJsonSchema.cs
@@ -79,7 +79,10 @@ internal sealed class PackagesJsonSchema
         // Deserialize JSON
         PackagesJsonSchema packagesSchema = FromJson(jsonString);
         ArgumentNullException.ThrowIfNull(packagesSchema);
-        ArgumentOutOfRangeException.ThrowIfZero(packagesSchema.Packages.Count);
+        if (packagesSchema.Packages.Count == 0)
+        {
+            throw new InvalidOperationException($"No packages found in {packagesUri}");
+        }
 
         // Return packages
         return packagesSchema.Packages;

--- a/CreateMatrix/ProductInfo.cs
+++ b/CreateMatrix/ProductInfo.cs
@@ -33,8 +33,14 @@ internal sealed class ProductInfo
             ProductType.NxWitness => "default",
             ProductType.DWSpectrum => "digitalwatchdog",
             ProductType.WisenetWAVE => "hanwha",
-            ProductType.None => throw new NotImplementedException(),
-            _ => throw new InvalidEnumArgumentException(nameof(Product)),
+            ProductType.None => throw new InvalidOperationException(
+                $"{nameof(ProductType)} is None"
+            ),
+            _ => throw new InvalidEnumArgumentException(
+                nameof(productType),
+                (int)productType,
+                typeof(ProductType)
+            ),
         };
 
     // Used for ${COMPANY_NAME} mediaserver install path and user account
@@ -46,8 +52,14 @@ internal sealed class ProductInfo
             ProductType.NxWitness => "networkoptix",
             ProductType.DWSpectrum => "digitalwatchdog",
             ProductType.WisenetWAVE => "hanwha",
-            ProductType.None => throw new NotImplementedException(),
-            _ => throw new InvalidEnumArgumentException(nameof(Product)),
+            ProductType.None => throw new InvalidOperationException(
+                $"{nameof(ProductType)} is None"
+            ),
+            _ => throw new InvalidEnumArgumentException(
+                nameof(productType),
+                (int)productType,
+                typeof(ProductType)
+            ),
         };
 
     // Used for ${LABEL_DESCRIPTION} in Dockerfile
@@ -59,12 +71,20 @@ internal sealed class ProductInfo
             ProductType.NxWitness => "Nx Witness VMS",
             ProductType.DWSpectrum => "DW Spectrum IPVMS",
             ProductType.WisenetWAVE => "Wisenet WAVE VMS",
-            ProductType.None => throw new NotImplementedException(),
-            _ => throw new InvalidEnumArgumentException(nameof(Product)),
+            ProductType.None => throw new InvalidOperationException(
+                $"{nameof(ProductType)} is None"
+            ),
+            _ => throw new InvalidEnumArgumentException(
+                nameof(productType),
+                (int)productType,
+                typeof(ProductType)
+            ),
         };
 
-    // Dockerfile name, excluding the .Dockerfile extension
-    // TODO: Consolidate with ImageInfo.SetName(), e.g. add enum for Ubuntu, LSIO, etc.
+    // Dockerfile name, excluding the .Dockerfile extension.
+    // This is the single source of the image/Dockerfile naming convention; ImageInfo derives its
+    // name from here. The base variant is a bool (Ubuntu vs LSIO); promote it to an enum only if a
+    // third base type is ever added (which would also ripple through ComposeFile/DockerFile).
     public static string GetDocker(ProductType productType, bool lsio) =>
         $"{productType}{(lsio ? "-LSIO" : "")}";
 
@@ -81,9 +101,6 @@ internal sealed class ProductInfo
 
     public async Task FetchVersionsAsync(CancellationToken cancellationToken)
     {
-        // Match the logic with ReleasesTests.CreateProductInfo()
-        // TODO: Refactor to reduce duplication and chance of divergence
-
         // Get version information using releases.json and package.json
         Log.Logger.Information("{Product}: Getting online release information...", Product);
         try
@@ -105,13 +122,8 @@ internal sealed class ProductInfo
                     continue;
                 }
 
-                // Set version
-                VersionInfo versionInfo = new();
-                Debug.Assert(!string.IsNullOrEmpty(release.Version));
-                versionInfo.SetVersion(release.Version);
-
-                // Add the label
-                AddLabel(versionInfo, release.GetLabel());
+                // Set the version and label
+                VersionInfo versionInfo = CreateVersionInfo(release);
 
                 // Get the build number from the version
                 int buildNumber = versionInfo.GetBuildNumber();
@@ -122,12 +134,28 @@ internal sealed class ProductInfo
                     .ConfigureAwait(false);
 
                 // Get the x64 and arm64 server ubuntu server packages
-                Package? packageX64 = packageList.Find(item => item.IsX64Server());
-                Debug.Assert(packageX64 != null);
-                Debug.Assert(!string.IsNullOrEmpty(packageX64.File));
-                Package? packageArm64 = packageList.Find(item => item.IsArm64Server());
-                Debug.Assert(packageArm64 != null);
-                Debug.Assert(!string.IsNullOrEmpty(packageArm64.File));
+                Package packageX64 =
+                    packageList.Find(item => item.IsX64Server())
+                    ?? throw new InvalidOperationException(
+                        $"{Product}: No x64 Ubuntu server package found for build {buildNumber} (version {versionInfo.Version})"
+                    );
+                if (string.IsNullOrEmpty(packageX64.File))
+                {
+                    throw new InvalidOperationException(
+                        $"{Product}: x64 Ubuntu server package for build {buildNumber} (version {versionInfo.Version}) has no file name"
+                    );
+                }
+                Package packageArm64 =
+                    packageList.Find(item => item.IsArm64Server())
+                    ?? throw new InvalidOperationException(
+                        $"{Product}: No arm64 Ubuntu server package found for build {buildNumber} (version {versionInfo.Version})"
+                    );
+                if (string.IsNullOrEmpty(packageArm64.File))
+                {
+                    throw new InvalidOperationException(
+                        $"{Product}: arm64 Ubuntu server package for build {buildNumber} (version {versionInfo.Version}) has no file name"
+                    );
+                }
 
                 // Create the download URLs
                 // https://updates.networkoptix.com/{product}/{build}/{file}
@@ -151,6 +179,22 @@ internal sealed class ProductInfo
             // Log and rethrow
             throw;
         }
+    }
+
+    public VersionInfo CreateVersionInfo(Release release)
+    {
+        // Create a version with its label from the release.
+        // Note: AddLabel() may move the label off other versions already in the list.
+        if (string.IsNullOrEmpty(release.Version))
+        {
+            throw new InvalidOperationException(
+                $"{Product}: Release has no version (publication type '{release.PublicationType}')"
+            );
+        }
+        VersionInfo versionInfo = new();
+        versionInfo.SetVersion(release.Version);
+        AddLabel(versionInfo, release.GetLabel());
+        return versionInfo;
     }
 
     private bool VerifyVersion(VersionInfo versionInfo)
@@ -285,6 +329,30 @@ internal sealed class ProductInfo
             Versions.Count(item => item.Labels.Contains(VersionInfo.LabelType.RC)),
             1
         );
+
+        // Must have no duplicate version numbers
+        VerifyNoDuplicateVersions();
+    }
+
+    public void VerifyNoDuplicateVersions()
+    {
+        // Each version number must appear at most once.
+        // Duplicates collapse when the matrix builds a set keyed by version number
+        // (see ImageInfo.CreateImages() and VersionInfoComparer) and must be rejected
+        // rather than written to the version file.
+        List<string> duplicateVersions =
+        [
+            .. Versions
+                .GroupBy(item => VersionInfo.ParseVersion(item.Version))
+                .Where(group => group.Count() > 1)
+                .Select(group => group.First().Version),
+        ];
+        if (duplicateVersions.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"{Product}: Duplicate version numbers found: {string.Join(", ", duplicateVersions)}"
+            );
+        }
     }
 
     public void LogInformation()

--- a/CreateMatrix/Program.cs
+++ b/CreateMatrix/Program.cs
@@ -114,6 +114,9 @@ internal sealed class Program(
             // Make sure the labelled version numbers do not regress
             ReleaseVersionForward.Verify(fileSchema.Products, onlineSchema.Products);
 
+            // Make sure the forward merge did not introduce duplicate version numbers
+            onlineSchema.Products.ForEach(productInfo => productInfo.VerifyNoDuplicateVersions());
+
             // Verify URL's
             foreach (ProductInfo productInfo in onlineSchema.Products)
             {

--- a/CreateMatrix/ReleaseVersionForward.cs
+++ b/CreateMatrix/ReleaseVersionForward.cs
@@ -28,13 +28,21 @@ internal static class ReleaseVersionForward
         VersionInfo.LabelType label
     )
     {
-        // TODO: It is possible that a label is released, then pulled, then re-released with a lesser version
+        // NOTE: Forward-only is intentional; a published tag must not regress to a lesser version.
+        // If a label is released, then pulled, then re-released with a lesser version, we keep the
+        // old (higher) version. This is harmless while the old build is still downloadable, and if
+        // its files were actually removed the run fails loudly in VerifyUrlsAsync (404) for a human
+        // to resolve, e.g. by manually adjusting Version.json. There is no silent-corruption path.
 
         // Find label in old and new product, skip if not present
         VersionInfo? oldVersion = oldProduct.Versions.Find(item => item.Labels.Contains(label));
         if (oldVersion == null)
         {
-            Log.Logger.Warning("{Product}:{Label} : Label not found", oldProduct.Product, label);
+            Log.Logger.Warning(
+                "{Product}:{Label} : Label not found in old versions",
+                oldProduct.Product,
+                label
+            );
             return;
         }
 
@@ -42,7 +50,11 @@ internal static class ReleaseVersionForward
         VersionInfo? newVersion = newProduct.Versions.Find(item => item.Labels.Contains(label));
         if (newVersion == null)
         {
-            Log.Logger.Warning("{Product}:{Label} : Label not found", newProduct.Product, label);
+            Log.Logger.Warning(
+                "{Product}:{Label} : Label not found in new versions",
+                newProduct.Product,
+                label
+            );
             return;
         }
 
@@ -71,16 +83,51 @@ internal static class ReleaseVersionForward
                 newVersion.Version
             );
 
-            // Replace the new version with the old version
+            // Remove the regressed new version
             _ = newProduct.Versions.Remove(newVersion);
-            newProduct.Versions.Add(oldVersion);
+
+            // The old version number may already be present in the new list under a different
+            // label (e.g. restoring Latest onto a version that is already Stable). Fold the
+            // old version's labels into that existing entry instead of adding a duplicate row,
+            // otherwise two entries would share a version number.
+            VersionInfo? existingVersion = newProduct.Versions.Find(item =>
+                item.CompareTo(oldVersion) == 0
+            );
+            if (existingVersion == null)
+            {
+                // No existing entry, add the old version
+                newProduct.Versions.Add(oldVersion);
+            }
+            else
+            {
+                // Fold the old version's labels into the existing entry
+                Log.Logger.Warning(
+                    "{Product}:{Label} Folding OldVersion: {OldVersion} labels into existing version",
+                    newProduct.Product,
+                    label,
+                    oldVersion.Version
+                );
+                foreach (VersionInfo.LabelType oldLabel in oldVersion.Labels)
+                {
+                    if (!existingVersion.Labels.Contains(oldLabel))
+                    {
+                        existingVersion.Labels.Add(oldLabel);
+                    }
+                }
+                existingVersion.Labels.Sort();
+            }
         }
         else
         {
-            // TODO: Unwind labels to replace only specific version-label pairs
+            // The label moved between versions that carry different label sets, so a surgical
+            // per-version-label swap is ambiguous. Rather than attempting to unwind individual
+            // version-label pairs, take the conservative approach and revert the whole product to
+            // the last-known-good versions. This may discard newer online versions until the
+            // regression clears, but it avoids producing an inconsistent label arrangement.
             Log.Logger.Warning(
-                "{Product}: Using old versions instead of new versions",
-                newProduct.Product
+                "{Product}:{Label} : Labels differ, reverting all versions to old versions",
+                newProduct.Product,
+                label
             );
 
             // Replace all versions if the labels do not match

--- a/CreateMatrix/ReleasesJsonSchema.cs
+++ b/CreateMatrix/ReleasesJsonSchema.cs
@@ -33,8 +33,8 @@ internal class Release
                 : VersionInfo.LabelType.Latest,
             RcPublication => VersionInfo.LabelType.RC,
             BetaPublication => VersionInfo.LabelType.Beta,
-            _ => throw new InvalidEnumArgumentException(
-                $"Unknown PublicationType: {PublicationType}"
+            _ => throw new InvalidOperationException(
+                $"Unknown publication type '{PublicationType}' for version {Version}"
             ),
         };
 
@@ -86,10 +86,46 @@ internal class ReleasesJsonSchema
         // Deserialize JSON
         ReleasesJsonSchema releasesSchema = FromJson(jsonString);
         ArgumentNullException.ThrowIfNull(releasesSchema);
-        ArgumentOutOfRangeException.ThrowIfZero(releasesSchema.Releases.Count);
+        if (releasesSchema.Releases.Count == 0)
+        {
+            throw new InvalidOperationException($"No releases found in {releasesUri}");
+        }
 
-        // Return releases
-        return releasesSchema.Releases;
+        // Verify the vendor data and return the folded releases
+        return VerifyReleases(releasesSchema.Releases);
+    }
+
+    public static List<Release> VerifyReleases(List<Release> releases)
+    {
+        // A version number must carry a single, unambiguous publication type.
+        // Fold benign duplicates (same version and publication type), reject conflicts.
+        ArgumentNullException.ThrowIfNull(releases);
+
+        List<Release> verifiedReleases = [];
+        foreach (
+            IGrouping<(string Product, Version Version), Release> group in releases.GroupBy(
+                release => (release.Product, VersionInfo.ParseVersion(release.Version))
+            )
+        )
+        {
+            // A version must not be tagged with more than one publication type
+            List<string> publicationTypes =
+            [
+                .. group
+                    .Select(release => release.PublicationType)
+                    .Distinct(StringComparer.OrdinalIgnoreCase),
+            ];
+            if (publicationTypes.Count > 1)
+            {
+                throw new InvalidOperationException(
+                    $"{group.Key.Product}: Version {group.First().Version} has conflicting publication types: {string.Join(", ", publicationTypes)}"
+                );
+            }
+
+            // Keep the first entry, folding any same-version same-type duplicates
+            verifiedReleases.Add(group.First());
+        }
+        return verifiedReleases;
     }
 }
 

--- a/CreateMatrix/ReleasesJsonSchema.cs
+++ b/CreateMatrix/ReleasesJsonSchema.cs
@@ -101,6 +101,21 @@ internal class ReleasesJsonSchema
         // Fold benign duplicates (same version and publication type), reject conflicts.
         ArgumentNullException.ThrowIfNull(releases);
 
+        // A version number must be present and parseable, otherwise grouping below would
+        // throw a context-free FormatException from Version parsing.
+        foreach (Release release in releases)
+        {
+            if (
+                string.IsNullOrEmpty(release.Version)
+                || !Version.TryParse(VersionInfo.NormalizeVersion(release.Version), out _)
+            )
+            {
+                throw new InvalidOperationException(
+                    $"{release.Product}: Invalid or missing version '{release.Version}' (publication type '{release.PublicationType}')"
+                );
+            }
+        }
+
         List<Release> verifiedReleases = [];
         foreach (
             IGrouping<(string Product, Version Version), Release> group in releases.GroupBy(

--- a/CreateMatrix/VersionInfo.cs
+++ b/CreateMatrix/VersionInfo.cs
@@ -20,27 +20,31 @@ internal sealed class VersionInfo
         // Extract the build number using the Version class (vs. regex)
         // 5.0.0.35271 -> 35271
         // 5.1.0.35151 R1 -> 35151
-        new Version(Version).Revision;
+        ParseVersion(Version).Revision;
 
-    public void SetVersion(string version)
+    public void SetVersion(string version) =>
+        // Store the normalized version number
+        Version = NormalizeVersion(version);
+
+    public static string NormalizeVersion(string version)
     {
-        // Remove Rxx from version string
+        // Remove the " Rxx" suffix from the version string
         // "5.0.0.35134 R10" -> "5.0.0.35134"
         int spaceIndex = version.IndexOf(' ', StringComparison.Ordinal);
-        Version = spaceIndex == -1 ? version : version[..spaceIndex];
+        return spaceIndex == -1 ? version : version[..spaceIndex];
     }
+
+    public static Version ParseVersion(string version) =>
+        // Parse the version number using the Version class, ignoring any " Rxx" suffix
+        new(NormalizeVersion(version));
 
     public int CompareTo(VersionInfo rhs) => Compare(this, rhs);
 
     public int CompareTo(string rhs) => Compare(Version, rhs);
 
-    public static int Compare(string lhs, string rhs)
-    {
+    public static int Compare(string lhs, string rhs) =>
         // Compare version numbers using Version class
-        Version lhsVersion = new(lhs);
-        Version rhsVersion = new(rhs);
-        return lhsVersion.CompareTo(rhsVersion);
-    }
+        ParseVersion(lhs).CompareTo(ParseVersion(rhs));
 
     public static int Compare(VersionInfo lhs, VersionInfo rhs) =>
         Compare(lhs.Version, rhs.Version);

--- a/CreateMatrix/VersionJsonSchema.cs
+++ b/CreateMatrix/VersionJsonSchema.cs
@@ -49,7 +49,9 @@ internal class VersionJsonSchema : VersionJsonSchemaBase
             // Breaking change, UriArm64 is required in ARM64 docker builds
             // Unknown version
             default:
-                throw new NotImplementedException();
+                throw new NotSupportedException(
+                    $"Unsupported schema version: {schemaVersion} (expected {Version})"
+                );
         }
     }
 }

--- a/CreateMatrixTests/ReleasesTests.cs
+++ b/CreateMatrixTests/ReleasesTests.cs
@@ -226,17 +226,71 @@ public sealed class ReleasesTests
         version.Version.Should().Be("4.0");
     }
 
+    [Fact]
+    public void ConflictingPublicationTypes_Throws()
+    {
+        // The same version number tagged with two different publication types is contradictory
+        // vendor data and must be rejected rather than folded into our data.
+        ReleasesJsonSchema releasesSchema = new()
+        {
+            Releases =
+            {
+                new Release
+                {
+                    PublicationType = Release.ReleasePublication,
+                    ReleaseDate = 1,
+                    ReleaseDeliveryDays = 1,
+                    Version = "6.1.2.42921",
+                },
+                new Release { PublicationType = Release.BetaPublication, Version = "6.1.2.42921" },
+            },
+        };
+
+        Action act = () => CreateProductInfo(releasesSchema);
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void DuplicatePublicationType_Folds()
+    {
+        // The same version number listed twice with the same publication type is a benign
+        // duplicate and is folded to a single entry.
+        ReleasesJsonSchema releasesSchema = new()
+        {
+            Releases =
+            {
+                new Release
+                {
+                    PublicationType = Release.ReleasePublication,
+                    ReleaseDate = 1,
+                    ReleaseDeliveryDays = 1,
+                    Version = "6.1.2.42921",
+                },
+                new Release
+                {
+                    PublicationType = Release.ReleasePublication,
+                    ReleaseDate = 1,
+                    ReleaseDeliveryDays = 1,
+                    Version = "6.1.2.42921",
+                },
+            },
+        };
+
+        ProductInfo productInfo = CreateProductInfo(releasesSchema);
+
+        // Folded to a single version
+        productInfo.Versions.Should().ContainSingle();
+        productInfo.Versions.First().Version.Should().Be("6.1.2.42921");
+    }
+
     private static ProductInfo CreateProductInfo(ReleasesJsonSchema releasesSchema)
     {
-        // Match the logic with ProductInfo.GetVersions()
-        // TODO: Refactor to reduce duplication and chance of divergence
+        // Mirror of the non-network portion of ProductInfo.FetchVersionsAsync(),
+        // sharing the version and label logic via ProductInfo.CreateVersionInfo().
         ProductInfo productInfo = new();
-        foreach (Release release in releasesSchema.Releases)
+        foreach (Release release in ReleasesJsonSchema.VerifyReleases(releasesSchema.Releases))
         {
-            VersionInfo versionInfo = new();
-            versionInfo.SetVersion(release.Version);
-            productInfo.AddLabel(versionInfo, release.GetLabel());
-            productInfo.Versions.Add(versionInfo);
+            productInfo.Versions.Add(productInfo.CreateVersionInfo(release));
         }
         productInfo.VerifyLabels();
 

--- a/CreateMatrixTests/ReleasesTests.cs
+++ b/CreateMatrixTests/ReleasesTests.cs
@@ -283,6 +283,29 @@ public sealed class ReleasesTests
         productInfo.Versions.First().Version.Should().Be("6.1.2.42921");
     }
 
+    [Fact]
+    public void MissingVersion_Throws()
+    {
+        // A release with a missing or unparseable version must be rejected with a clear
+        // error rather than a context-free version-parsing failure.
+        ReleasesJsonSchema releasesSchema = new()
+        {
+            Releases =
+            {
+                new Release
+                {
+                    PublicationType = Release.ReleasePublication,
+                    ReleaseDate = 1,
+                    ReleaseDeliveryDays = 1,
+                    Version = "",
+                },
+            },
+        };
+
+        Action act = () => CreateProductInfo(releasesSchema);
+        act.Should().Throw<InvalidOperationException>();
+    }
+
     private static ProductInfo CreateProductInfo(ReleasesJsonSchema releasesSchema)
     {
         // Mirror of the non-network portion of ProductInfo.FetchVersionsAsync(),

--- a/CreateMatrixTests/VersionForwardTests.cs
+++ b/CreateMatrixTests/VersionForwardTests.cs
@@ -175,4 +175,95 @@ public class VersionForwardTests
             ?.Version;
         betaVersion.Should().Be("4.0");
     }
+
+    [Fact]
+    public void VersionRegress_FoldsOntoExistingVersion()
+    {
+        // Reproduces the WisenetWAVE codegen failure: the online "Latest" regressed below a
+        // version that is already present as "Stable", so restoring the old "Latest" must fold
+        // onto the existing entry instead of adding a duplicate version row.
+        List<ProductInfo> oldProductList =
+        [
+            new ProductInfo
+            {
+                Product = ProductInfo.ProductType.WisenetWAVE,
+                Versions =
+                {
+                    new VersionInfo
+                    {
+                        Version = "6.0.5.41290",
+                        Labels = { VersionInfo.LabelType.Stable },
+                    },
+                    new VersionInfo
+                    {
+                        Version = "6.1.2.42921",
+                        Labels = { VersionInfo.LabelType.Latest },
+                    },
+                },
+            },
+        ];
+        List<ProductInfo> newProductList =
+        [
+            new ProductInfo
+            {
+                Product = ProductInfo.ProductType.WisenetWAVE,
+                Versions =
+                {
+                    new VersionInfo
+                    {
+                        Version = "6.1.1.42624",
+                        Labels = { VersionInfo.LabelType.Latest },
+                    },
+                    new VersionInfo
+                    {
+                        Version = "6.1.2.42921",
+                        Labels = { VersionInfo.LabelType.Stable },
+                    },
+                },
+            },
+        ];
+
+        ReleaseVersionForward.Verify(oldProductList, newProductList);
+        ProductInfo productInfo = newProductList.First();
+
+        // Folded to a single 6.1.2.42921 entry carrying both Stable and Latest
+        productInfo.Versions.Should().ContainSingle();
+        VersionInfo version = productInfo.Versions.First();
+        version.Version.Should().Be("6.1.2.42921");
+        version
+            .Labels.Should()
+            .BeEquivalentTo([VersionInfo.LabelType.Stable, VersionInfo.LabelType.Latest]);
+
+        // No duplicate version numbers
+        productInfo.Versions.Select(item => item.Version).Should().OnlyHaveUniqueItems();
+        productInfo.Invoking(item => item.VerifyNoDuplicateVersions()).Should().NotThrow();
+    }
+
+    [Fact]
+    public void VerifyNoDuplicateVersions_Throws()
+    {
+        // Two entries sharing a version number must be rejected
+        ProductInfo productInfo = new()
+        {
+            Product = ProductInfo.ProductType.NxMeta,
+            Versions =
+            {
+                new VersionInfo
+                {
+                    Version = "6.1.2.42921",
+                    Labels = { VersionInfo.LabelType.Stable },
+                },
+                new VersionInfo
+                {
+                    Version = "6.1.2.42921",
+                    Labels = { VersionInfo.LabelType.Latest },
+                },
+            },
+        };
+
+        productInfo
+            .Invoking(item => item.VerifyNoDuplicateVersions())
+            .Should()
+            .Throw<InvalidOperationException>();
+    }
 }

--- a/Docker/DWSpectrum-LSIO.Dockerfile
+++ b/Docker/DWSpectrum-LSIO.Dockerfile
@@ -13,13 +13,13 @@ FROM docker.io/ptr727/nx-base-lsio:ubuntu-noble
 # Labels
 ARG LABEL_NAME="DWSpectrum-LSIO"
 ARG LABEL_DESCRIPTION="DW Spectrum IPVMS"
-ARG LABEL_VERSION="6.1.1.42624"
+ARG LABEL_VERSION="6.1.2.42997"
 
 # Download URL and version
 # Current values are defined by the build pipeline
-ARG DOWNLOAD_X64_URL="https://updates.networkoptix.com/digitalwatchdog/42624/dwspectrum-server_update-6.1.1.42624-linux_x64.zip"
-ARG DOWNLOAD_ARM64_URL="https://updates.networkoptix.com/digitalwatchdog/42624/dwspectrum-server_update-6.1.1.42624-linux_arm64.zip"
-ARG DOWNLOAD_VERSION="6.1.1.42624"
+ARG DOWNLOAD_X64_URL="https://updates.networkoptix.com/digitalwatchdog/42997/dwspectrum-server_update-6.1.2.42997-linux_x64.zip"
+ARG DOWNLOAD_ARM64_URL="https://updates.networkoptix.com/digitalwatchdog/42997/dwspectrum-server_update-6.1.2.42997-linux_arm64.zip"
+ARG DOWNLOAD_VERSION="6.1.2.42997"
 
 # Used for ${COMPANY_NAME} setting the server user and install directory
 ARG RUNTIME_NAME="digitalwatchdog"

--- a/Docker/DWSpectrum.Dockerfile
+++ b/Docker/DWSpectrum.Dockerfile
@@ -13,13 +13,13 @@ FROM docker.io/ptr727/nx-base:ubuntu-noble
 # Labels
 ARG LABEL_NAME="DWSpectrum"
 ARG LABEL_DESCRIPTION="DW Spectrum IPVMS"
-ARG LABEL_VERSION="6.1.1.42624"
+ARG LABEL_VERSION="6.1.2.42997"
 
 # Download URL and version
 # Current values are defined by the build pipeline
-ARG DOWNLOAD_X64_URL="https://updates.networkoptix.com/digitalwatchdog/42624/dwspectrum-server_update-6.1.1.42624-linux_x64.zip"
-ARG DOWNLOAD_ARM64_URL="https://updates.networkoptix.com/digitalwatchdog/42624/dwspectrum-server_update-6.1.1.42624-linux_arm64.zip"
-ARG DOWNLOAD_VERSION="6.1.1.42624"
+ARG DOWNLOAD_X64_URL="https://updates.networkoptix.com/digitalwatchdog/42997/dwspectrum-server_update-6.1.2.42997-linux_x64.zip"
+ARG DOWNLOAD_ARM64_URL="https://updates.networkoptix.com/digitalwatchdog/42997/dwspectrum-server_update-6.1.2.42997-linux_arm64.zip"
+ARG DOWNLOAD_VERSION="6.1.2.42997"
 
 # Used for ${COMPANY_NAME} setting the server user and install directory
 ARG RUNTIME_NAME="digitalwatchdog"

--- a/Docker/NxGo-LSIO.Dockerfile
+++ b/Docker/NxGo-LSIO.Dockerfile
@@ -13,13 +13,13 @@ FROM docker.io/ptr727/nx-base-lsio:ubuntu-noble
 # Labels
 ARG LABEL_NAME="NxGo-LSIO"
 ARG LABEL_DESCRIPTION="Nx Go VMS"
-ARG LABEL_VERSION="6.1.1.42624"
+ARG LABEL_VERSION="6.1.2.42921"
 
 # Download URL and version
 # Current values are defined by the build pipeline
-ARG DOWNLOAD_X64_URL="https://updates.networkoptix.com/nxgo/42624/nxgo-server_update-6.1.1.42624-linux_x64.zip"
-ARG DOWNLOAD_ARM64_URL="https://updates.networkoptix.com/nxgo/42624/nxgo-server_update-6.1.1.42624-linux_arm64.zip"
-ARG DOWNLOAD_VERSION="6.1.1.42624"
+ARG DOWNLOAD_X64_URL="https://updates.networkoptix.com/nxgo/42921/nxgo-server_update-6.1.2.42921-linux_x64.zip"
+ARG DOWNLOAD_ARM64_URL="https://updates.networkoptix.com/nxgo/42921/nxgo-server_update-6.1.2.42921-linux_arm64.zip"
+ARG DOWNLOAD_VERSION="6.1.2.42921"
 
 # Used for ${COMPANY_NAME} setting the server user and install directory
 ARG RUNTIME_NAME="networkoptix"

--- a/Docker/NxGo.Dockerfile
+++ b/Docker/NxGo.Dockerfile
@@ -13,13 +13,13 @@ FROM docker.io/ptr727/nx-base:ubuntu-noble
 # Labels
 ARG LABEL_NAME="NxGo"
 ARG LABEL_DESCRIPTION="Nx Go VMS"
-ARG LABEL_VERSION="6.1.1.42624"
+ARG LABEL_VERSION="6.1.2.42921"
 
 # Download URL and version
 # Current values are defined by the build pipeline
-ARG DOWNLOAD_X64_URL="https://updates.networkoptix.com/nxgo/42624/nxgo-server_update-6.1.1.42624-linux_x64.zip"
-ARG DOWNLOAD_ARM64_URL="https://updates.networkoptix.com/nxgo/42624/nxgo-server_update-6.1.1.42624-linux_arm64.zip"
-ARG DOWNLOAD_VERSION="6.1.1.42624"
+ARG DOWNLOAD_X64_URL="https://updates.networkoptix.com/nxgo/42921/nxgo-server_update-6.1.2.42921-linux_x64.zip"
+ARG DOWNLOAD_ARM64_URL="https://updates.networkoptix.com/nxgo/42921/nxgo-server_update-6.1.2.42921-linux_arm64.zip"
+ARG DOWNLOAD_VERSION="6.1.2.42921"
 
 # Used for ${COMPANY_NAME} setting the server user and install directory
 ARG RUNTIME_NAME="networkoptix"

--- a/Docker/NxMeta-LSIO.Dockerfile
+++ b/Docker/NxMeta-LSIO.Dockerfile
@@ -13,13 +13,13 @@ FROM docker.io/ptr727/nx-base-lsio:ubuntu-noble
 # Labels
 ARG LABEL_NAME="NxMeta-LSIO"
 ARG LABEL_DESCRIPTION="Nx Meta VMS"
-ARG LABEL_VERSION="6.1.1.42624"
+ARG LABEL_VERSION="6.1.1.42649"
 
 # Download URL and version
 # Current values are defined by the build pipeline
-ARG DOWNLOAD_X64_URL="https://updates.networkoptix.com/metavms/42624/metavms-server_update-6.1.1.42624-linux_x64.zip"
-ARG DOWNLOAD_ARM64_URL="https://updates.networkoptix.com/metavms/42624/metavms-server_update-6.1.1.42624-linux_arm64.zip"
-ARG DOWNLOAD_VERSION="6.1.1.42624"
+ARG DOWNLOAD_X64_URL="https://updates.networkoptix.com/metavms/42649/metavms-server_update-6.1.1.42649-linux_x64.zip"
+ARG DOWNLOAD_ARM64_URL="https://updates.networkoptix.com/metavms/42649/metavms-server_update-6.1.1.42649-linux_arm64.zip"
+ARG DOWNLOAD_VERSION="6.1.1.42649"
 
 # Used for ${COMPANY_NAME} setting the server user and install directory
 ARG RUNTIME_NAME="networkoptix-metavms"

--- a/Docker/NxMeta.Dockerfile
+++ b/Docker/NxMeta.Dockerfile
@@ -13,13 +13,13 @@ FROM docker.io/ptr727/nx-base:ubuntu-noble
 # Labels
 ARG LABEL_NAME="NxMeta"
 ARG LABEL_DESCRIPTION="Nx Meta VMS"
-ARG LABEL_VERSION="6.1.1.42624"
+ARG LABEL_VERSION="6.1.1.42649"
 
 # Download URL and version
 # Current values are defined by the build pipeline
-ARG DOWNLOAD_X64_URL="https://updates.networkoptix.com/metavms/42624/metavms-server_update-6.1.1.42624-linux_x64.zip"
-ARG DOWNLOAD_ARM64_URL="https://updates.networkoptix.com/metavms/42624/metavms-server_update-6.1.1.42624-linux_arm64.zip"
-ARG DOWNLOAD_VERSION="6.1.1.42624"
+ARG DOWNLOAD_X64_URL="https://updates.networkoptix.com/metavms/42649/metavms-server_update-6.1.1.42649-linux_x64.zip"
+ARG DOWNLOAD_ARM64_URL="https://updates.networkoptix.com/metavms/42649/metavms-server_update-6.1.1.42649-linux_arm64.zip"
+ARG DOWNLOAD_VERSION="6.1.1.42649"
 
 # Used for ${COMPANY_NAME} setting the server user and install directory
 ARG RUNTIME_NAME="networkoptix-metavms"

--- a/Docker/NxWitness-LSIO.Dockerfile
+++ b/Docker/NxWitness-LSIO.Dockerfile
@@ -13,13 +13,13 @@ FROM docker.io/ptr727/nx-base-lsio:ubuntu-noble
 # Labels
 ARG LABEL_NAME="NxWitness-LSIO"
 ARG LABEL_DESCRIPTION="Nx Witness VMS"
-ARG LABEL_VERSION="6.1.1.42624"
+ARG LABEL_VERSION="6.1.2.42921"
 
 # Download URL and version
 # Current values are defined by the build pipeline
-ARG DOWNLOAD_X64_URL="https://updates.networkoptix.com/default/42624/nxwitness-server_update-6.1.1.42624-linux_x64.zip"
-ARG DOWNLOAD_ARM64_URL="https://updates.networkoptix.com/default/42624/nxwitness-server_update-6.1.1.42624-linux_arm64.zip"
-ARG DOWNLOAD_VERSION="6.1.1.42624"
+ARG DOWNLOAD_X64_URL="https://updates.networkoptix.com/default/42921/nxwitness-server_update-6.1.2.42921-linux_x64.zip"
+ARG DOWNLOAD_ARM64_URL="https://updates.networkoptix.com/default/42921/nxwitness-server_update-6.1.2.42921-linux_arm64.zip"
+ARG DOWNLOAD_VERSION="6.1.2.42921"
 
 # Used for ${COMPANY_NAME} setting the server user and install directory
 ARG RUNTIME_NAME="networkoptix"

--- a/Docker/NxWitness.Dockerfile
+++ b/Docker/NxWitness.Dockerfile
@@ -13,13 +13,13 @@ FROM docker.io/ptr727/nx-base:ubuntu-noble
 # Labels
 ARG LABEL_NAME="NxWitness"
 ARG LABEL_DESCRIPTION="Nx Witness VMS"
-ARG LABEL_VERSION="6.1.1.42624"
+ARG LABEL_VERSION="6.1.2.42921"
 
 # Download URL and version
 # Current values are defined by the build pipeline
-ARG DOWNLOAD_X64_URL="https://updates.networkoptix.com/default/42624/nxwitness-server_update-6.1.1.42624-linux_x64.zip"
-ARG DOWNLOAD_ARM64_URL="https://updates.networkoptix.com/default/42624/nxwitness-server_update-6.1.1.42624-linux_arm64.zip"
-ARG DOWNLOAD_VERSION="6.1.1.42624"
+ARG DOWNLOAD_X64_URL="https://updates.networkoptix.com/default/42921/nxwitness-server_update-6.1.2.42921-linux_x64.zip"
+ARG DOWNLOAD_ARM64_URL="https://updates.networkoptix.com/default/42921/nxwitness-server_update-6.1.2.42921-linux_arm64.zip"
+ARG DOWNLOAD_VERSION="6.1.2.42921"
 
 # Used for ${COMPANY_NAME} setting the server user and install directory
 ARG RUNTIME_NAME="networkoptix"

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,8 @@ This is a project to build and publish docker images for various [Network Optix]
 
 ## Release History
 
+- Version 2.13:
+  - Fixed a regression bug that surfaced when Nx released an older version under the same tag, triggering the version-forward-release only logic.
 - Version 2.12:
   - Reworked the CI pipeline: pull requests run a fast representative amd64 smoke build (NxMeta and NxMeta-LSIO) instead of the full matrix, publishing moved to a weekly schedule (and manual trigger) that builds both the `main` and `develop` branches in one run, and merges no longer republish images. This speeds up PR feedback, reduces GH Actions usage, and stops no-op image updates for consumers.
 - Version 2.11:

--- a/Make/Matrix.json
+++ b/Make/Matrix.json
@@ -375,13 +375,13 @@
       "Branch": "main",
       "Base": "ubuntu",
       "Tags": [
-        "docker.io/ptr727/wisenetwave:6.0.5.41290",
-        "docker.io/ptr727/wisenetwave:stable"
+        "docker.io/ptr727/wisenetwave:6.1.1.42624",
+        "docker.io/ptr727/wisenetwave:latest"
       ],
       "Args": [
-        "DOWNLOAD_ARM64_URL=https://updates.networkoptix.com/hanwha/41290/wave-server_update-6.0.5.41290-linux_arm64.zip",
-        "DOWNLOAD_VERSION=6.0.5.41290",
-        "DOWNLOAD_X64_URL=https://updates.networkoptix.com/hanwha/41290/wave-server_update-6.0.5.41290-linux_x64.zip"
+        "DOWNLOAD_ARM64_URL=https://updates.networkoptix.com/hanwha/42624/wave-server_update-6.1.1.42624-linux_arm64.zip",
+        "DOWNLOAD_VERSION=6.1.1.42624",
+        "DOWNLOAD_X64_URL=https://updates.networkoptix.com/hanwha/42624/wave-server_update-6.1.1.42624-linux_x64.zip"
       ]
     },
     {
@@ -391,27 +391,12 @@
       "Base": "ubuntu",
       "Tags": [
         "docker.io/ptr727/wisenetwave:6.1.2.42921",
-        "docker.io/ptr727/wisenetwave:latest"
+        "docker.io/ptr727/wisenetwave:stable"
       ],
       "Args": [
         "DOWNLOAD_ARM64_URL=https://updates.networkoptix.com/hanwha/42921/wave-server_update-6.1.2.42921-linux_arm64.zip",
         "DOWNLOAD_VERSION=6.1.2.42921",
         "DOWNLOAD_X64_URL=https://updates.networkoptix.com/hanwha/42921/wave-server_update-6.1.2.42921-linux_x64.zip"
-      ]
-    },
-    {
-      "Name": "WisenetWAVE",
-      "Product": "wisenetwave",
-      "Branch": "develop",
-      "Base": "ubuntu",
-      "Tags": [
-        "docker.io/ptr727/wisenetwave:develop-6.0.5.41290",
-        "docker.io/ptr727/wisenetwave:develop-stable"
-      ],
-      "Args": [
-        "DOWNLOAD_ARM64_URL=https://updates.networkoptix.com/hanwha/41290/wave-server_update-6.0.5.41290-linux_arm64.zip",
-        "DOWNLOAD_VERSION=6.0.5.41290",
-        "DOWNLOAD_X64_URL=https://updates.networkoptix.com/hanwha/41290/wave-server_update-6.0.5.41290-linux_x64.zip"
       ]
     },
     {
@@ -421,7 +406,22 @@
       "Base": "ubuntu",
       "Tags": [
         "docker.io/ptr727/wisenetwave:develop",
-        "docker.io/ptr727/wisenetwave:develop-6.1.2.42921"
+        "docker.io/ptr727/wisenetwave:develop-6.1.1.42624"
+      ],
+      "Args": [
+        "DOWNLOAD_ARM64_URL=https://updates.networkoptix.com/hanwha/42624/wave-server_update-6.1.1.42624-linux_arm64.zip",
+        "DOWNLOAD_VERSION=6.1.1.42624",
+        "DOWNLOAD_X64_URL=https://updates.networkoptix.com/hanwha/42624/wave-server_update-6.1.1.42624-linux_x64.zip"
+      ]
+    },
+    {
+      "Name": "WisenetWAVE",
+      "Product": "wisenetwave",
+      "Branch": "develop",
+      "Base": "ubuntu",
+      "Tags": [
+        "docker.io/ptr727/wisenetwave:develop-6.1.2.42921",
+        "docker.io/ptr727/wisenetwave:develop-stable"
       ],
       "Args": [
         "DOWNLOAD_ARM64_URL=https://updates.networkoptix.com/hanwha/42921/wave-server_update-6.1.2.42921-linux_arm64.zip",
@@ -435,13 +435,13 @@
       "Branch": "main",
       "Base": "lsio",
       "Tags": [
-        "docker.io/ptr727/wisenetwave-lsio:6.0.5.41290",
-        "docker.io/ptr727/wisenetwave-lsio:stable"
+        "docker.io/ptr727/wisenetwave-lsio:6.1.1.42624",
+        "docker.io/ptr727/wisenetwave-lsio:latest"
       ],
       "Args": [
-        "DOWNLOAD_ARM64_URL=https://updates.networkoptix.com/hanwha/41290/wave-server_update-6.0.5.41290-linux_arm64.zip",
-        "DOWNLOAD_VERSION=6.0.5.41290",
-        "DOWNLOAD_X64_URL=https://updates.networkoptix.com/hanwha/41290/wave-server_update-6.0.5.41290-linux_x64.zip"
+        "DOWNLOAD_ARM64_URL=https://updates.networkoptix.com/hanwha/42624/wave-server_update-6.1.1.42624-linux_arm64.zip",
+        "DOWNLOAD_VERSION=6.1.1.42624",
+        "DOWNLOAD_X64_URL=https://updates.networkoptix.com/hanwha/42624/wave-server_update-6.1.1.42624-linux_x64.zip"
       ]
     },
     {
@@ -451,7 +451,7 @@
       "Base": "lsio",
       "Tags": [
         "docker.io/ptr727/wisenetwave-lsio:6.1.2.42921",
-        "docker.io/ptr727/wisenetwave-lsio:latest"
+        "docker.io/ptr727/wisenetwave-lsio:stable"
       ],
       "Args": [
         "DOWNLOAD_ARM64_URL=https://updates.networkoptix.com/hanwha/42921/wave-server_update-6.1.2.42921-linux_arm64.zip",
@@ -465,13 +465,13 @@
       "Branch": "develop",
       "Base": "lsio",
       "Tags": [
-        "docker.io/ptr727/wisenetwave-lsio:develop-6.0.5.41290",
-        "docker.io/ptr727/wisenetwave-lsio:develop-stable"
+        "docker.io/ptr727/wisenetwave-lsio:develop",
+        "docker.io/ptr727/wisenetwave-lsio:develop-6.1.1.42624"
       ],
       "Args": [
-        "DOWNLOAD_ARM64_URL=https://updates.networkoptix.com/hanwha/41290/wave-server_update-6.0.5.41290-linux_arm64.zip",
-        "DOWNLOAD_VERSION=6.0.5.41290",
-        "DOWNLOAD_X64_URL=https://updates.networkoptix.com/hanwha/41290/wave-server_update-6.0.5.41290-linux_x64.zip"
+        "DOWNLOAD_ARM64_URL=https://updates.networkoptix.com/hanwha/42624/wave-server_update-6.1.1.42624-linux_arm64.zip",
+        "DOWNLOAD_VERSION=6.1.1.42624",
+        "DOWNLOAD_X64_URL=https://updates.networkoptix.com/hanwha/42624/wave-server_update-6.1.1.42624-linux_x64.zip"
       ]
     },
     {
@@ -480,8 +480,8 @@
       "Branch": "develop",
       "Base": "lsio",
       "Tags": [
-        "docker.io/ptr727/wisenetwave-lsio:develop",
-        "docker.io/ptr727/wisenetwave-lsio:develop-6.1.2.42921"
+        "docker.io/ptr727/wisenetwave-lsio:develop-6.1.2.42921",
+        "docker.io/ptr727/wisenetwave-lsio:develop-stable"
       ],
       "Args": [
         "DOWNLOAD_ARM64_URL=https://updates.networkoptix.com/hanwha/42921/wave-server_update-6.1.2.42921-linux_arm64.zip",

--- a/Make/Version.json
+++ b/Make/Version.json
@@ -75,11 +75,11 @@
       "Product": "WisenetWAVE",
       "Versions": [
         {
-          "Version": "6.0.5.41290",
-          "UriX64": "https://updates.networkoptix.com/hanwha/41290/wave-server_update-6.0.5.41290-linux_x64.zip",
-          "UriArm64": "https://updates.networkoptix.com/hanwha/41290/wave-server_update-6.0.5.41290-linux_arm64.zip",
+          "Version": "6.1.1.42624",
+          "UriX64": "https://updates.networkoptix.com/hanwha/42624/wave-server_update-6.1.1.42624-linux_x64.zip",
+          "UriArm64": "https://updates.networkoptix.com/hanwha/42624/wave-server_update-6.1.1.42624-linux_arm64.zip",
           "Labels": [
-            "Stable"
+            "Latest"
           ]
         },
         {
@@ -87,7 +87,7 @@
           "UriX64": "https://updates.networkoptix.com/hanwha/42921/wave-server_update-6.1.2.42921-linux_x64.zip",
           "UriArm64": "https://updates.networkoptix.com/hanwha/42921/wave-server_update-6.1.2.42921-linux_arm64.zip",
           "Labels": [
-            "Latest"
+            "Stable"
           ]
         }
       ]

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ This is a project to build and publish docker images for various [Network Optix]
 
 ### Release Notes
 
-**Version: 2.12**:
+**Version: 2.13**:
 
 **Summary**:
 
-- Reworked the CI pipeline: pull requests run a fast representative amd64 smoke build (`NxMeta` and `NxMeta-LSIO`) instead of the full matrix, publishing moved to a weekly schedule (and manual trigger) that builds both the `main` and `develop` branches in one run, and merges no longer republish images.
+- Fixed a regression bug that surfaced when Nx released an older version under the same tag, triggering the version-forward-release only logic.
 
 See [Release History](./HISTORY.md) for complete release notes and older versions.
 
@@ -130,37 +130,36 @@ services:
 
 ## Table of Contents
 
-- [Docker Projects for Network Optix VMS Products](#docker-projects-for-network-optix-vms-products)
-  - [Build and Distribution](#build-and-distribution)
-    - [Build Status](#build-status)
-    - [Release Notes](#release-notes)
-  - [Getting Started](#getting-started)
-  - [Table of Contents](#table-of-contents)
-  - [Products](#products)
-  - [Releases](#releases)
-  - [Overview](#overview)
-    - [Introduction](#introduction)
-    - [Base Images](#base-images)
-    - [LinuxServer](#linuxserver)
-  - [Configuration](#configuration)
-    - [LSIO Volumes](#lsio-volumes)
-    - [Non-LSIO Volumes](#non-lsio-volumes)
-    - [Ports](#ports)
-    - [Environment Variables](#environment-variables)
-    - [Network Mode](#network-mode)
-  - [Examples](#examples)
-    - [LSIO Docker Create](#lsio-docker-create)
-    - [LSIO Docker Compose](#lsio-docker-compose)
-    - [Non-LSIO Docker Compose](#non-lsio-docker-compose)
-    - [Unraid Template](#unraid-template)
-  - [Product Information](#product-information)
-    - [Release Information](#release-information)
-    - [Advanced Configuration](#advanced-configuration)
-  - [Build Process](#build-process)
-  - [Known Issues](#known-issues)
-  - [Troubleshooting](#troubleshooting)
-    - [Missing Storage](#missing-storage)
-  - [License](#license)
+- [Build and Distribution](#build-and-distribution)
+  - [Build Status](#build-status)
+  - [Release Notes](#release-notes)
+- [Getting Started](#getting-started)
+- [Table of Contents](#table-of-contents)
+- [Products](#products)
+- [Releases](#releases)
+- [Overview](#overview)
+  - [Introduction](#introduction)
+  - [Base Images](#base-images)
+  - [LinuxServer](#linuxserver)
+- [Configuration](#configuration)
+  - [LSIO Volumes](#lsio-volumes)
+  - [Non-LSIO Volumes](#non-lsio-volumes)
+  - [Ports](#ports)
+  - [Environment Variables](#environment-variables)
+  - [Network Mode](#network-mode)
+- [Examples](#examples)
+  - [LSIO Docker Create](#lsio-docker-create)
+  - [LSIO Docker Compose](#lsio-docker-compose)
+  - [Non-LSIO Docker Compose](#non-lsio-docker-compose)
+  - [Unraid Template](#unraid-template)
+- [Product Information](#product-information)
+  - [Release Information](#release-information)
+  - [Advanced Configuration](#advanced-configuration)
+- [Build Process](#build-process)
+- [Known Issues](#known-issues)
+- [Troubleshooting](#troubleshooting)
+  - [Missing Storage](#missing-storage)
+- [License](#license)
 
 ## Products
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.13",
+  "version": "2.14",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
## Problem

The daily **CodeGen** action started failing with **exit code 134 (SIGABRT)** — a failed `Debug.Assert(versionSet.Count == productInfo.Versions.Count)` in `ImageInfo.CreateImages`. Reproduced from the WisenetWAVE trace: the online *Latest* regressed below a version already present as *Stable*, and `ReleaseVersionForward` restored the old *Latest* by **adding a second row** for `6.1.2.42921`, so two entries shared a version number and collapsed in the sorted set.

The vendor JSON was valid — our anti-regression merge created the duplicate.

## Fix

- **`ReleaseVersionForward`**: fold the restored label into the existing same-version entry instead of adding a duplicate row → `6.1.2[Stable, Latest]`.
- **`ProductInfo.VerifyNoDuplicateVersions()`**: an all-build guard that throws (with product + versions) before the version file is written, covering both the fetch and forward-merge paths. The `Debug.Assert` stays as a backstop.
- **Defensive vendor parsing** (`ReleasesJsonSchema.VerifyReleases`): reject `releases.json` that tags one version number with conflicting publication types; fold benign same-type duplicates.

## Hardening / cleanup

- Consolidated version parsing into `VersionInfo.NormalizeVersion`/`ParseVersion`, and the version/label assembly into `ProductInfo.CreateVersionInfo` (shared with the test mirror, removing the divergence-prone duplication).
- Made failure paths descriptive: replaced context-free `Debug.Assert`/bare exceptions on the vendor-data paths with messages carrying product, build number, version, and URL; disambiguated "label not found" warnings.

## Tests

- WisenetWAVE regression (folds to one `6.1.2` entry with both labels, no duplicate numbers).
- `VerifyNoDuplicateVersions` throws on duplicates.
- Invalid vendor JSON: throws on conflicting publication types, folds same-type duplicates.

All 20 tests pass; CSharpier + `dotnet format style` clean.

## Release chore (maintainer-prepared)

Regenerated `Docker/*` and `Make/{Version,Matrix}.json`, release notes in `README.md` / `HISTORY.md` (Version 2.13), and `version.json` floor bump to 2.14 (keeps develop a minor ahead).