### PR TITLE
Restore version floor to 2.13

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.14",
+  "version": "2.13",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
The 2.13 release chore (merged in #436) bumped `version.json` to 2.14, but this release ships as **2.13** (see README/HISTORY). The next-cycle bump to 2.14 is a separate post-release step per AGENTS.md versioning, so restore the floor to 2.13.

Only `version.json` changes; no image files, so no smoke build.