### PR TITLE
Realign copilot-instructions.md with ProjectTemplate lean form

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -169,6 +169,6 @@ After the final push, sweep-resolve stale older threads for removed code paths.
 
 ## When in Doubt
 
-Read [AGENTS.md](../AGENTS.md) for the full picture (release flow, files you must not touch, branching, workflow YAML). For language-specific rules, [`CODESTYLE.md`](../CODESTYLE.md) is authoritative. Don't restate any of these files' rules in commit bodies or PR descriptions - keep those focused on the change itself.
+Read [AGENTS.md](../AGENTS.md) for the full picture (release flow, branching, workflow conventions, coding conventions, notes for changes). For language-specific rules, [`CODESTYLE.md`](../CODESTYLE.md) is authoritative. Don't restate any of these files' rules in commit bodies or PR descriptions - keep those focused on the change itself.
 
 **In a derived repo:** if you find a discrepancy that should be fixed in the template itself (this file or AGENTS.md is out of date, a rule is missing, something bit this repo and would bite the next), open an issue upstream in [`ptr727/ProjectTemplate`](https://github.com/ptr727/ProjectTemplate) rather than only fixing it locally - see [ProjectTemplate AGENTS.md "Staying in Sync and Reporting Drift Upstream"](https://github.com/ptr727/ProjectTemplate/blob/main/AGENTS.md#staying-in-sync-and-reporting-drift-upstream).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,8 +44,6 @@ Clarify LSIO volume configuration in README
 
 ## GitHub Copilot Review Runbook
 
-> **Carry this runbook verbatim into every derived repo.** This whole file is a drop-in: copy it as-is and change only the `<owner>` / `<repo>` / `<N>` placeholders in the snippets below (and drop the language-specific style pointers that don't apply). It pairs with the [AGENTS.md "PR Review Etiquette"](../AGENTS.md#pr-review-etiquette) contract, which is also a mandatory verbatim carry - see [ProjectTemplate AGENTS.md "Files and Sections Derived Repos Must Carry Verbatim"](https://github.com/ptr727/ProjectTemplate/blob/main/AGENTS.md#files-and-sections-derived-repos-must-carry-verbatim). A derived repo without this runbook in-repo has no pointer to the reliable Copilot mechanics and falls back to known-broken paths (the no-op `POST /requested_reviewers`, the wrong bot-login filter).
-
 Use this section for provider-specific mechanics. The expected review loop *contract* (request review on every push, verify head-SHA coverage, triage findings, reply + resolve, escalate when stuck) is defined in [AGENTS.md -> PR Review Etiquette](../AGENTS.md#pr-review-etiquette). This section only describes how to make GitHub Copilot reliably execute it.
 
 ### Triggering and Polling

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,67 +1,50 @@
-# GitHub Copilot Guidance
+# Copilot Instructions
 
-## Purpose
+Repository conventions for GitHub Copilot (and any other AI agent reading this file).
 
-This file summarizes the solution and defines the hierarchy of guidance for AI-assisted contributions.
+The **canonical guide is [AGENTS.md](../AGENTS.md)** at the repo root - read it first. It covers project layout, branch flow, PR review etiquette, the release pipeline, workflow YAML conventions, and what NOT to touch.
 
-## Guidance Hierarchy (Must Follow)
+This file is intentionally narrow: commit/PR-title conventions (so VS Code's AI commit-message and PR-title generators get them without an extra fetch), plus a GitHub Copilot Review Runbook that documents the provider-specific mechanics behind the review-loop contract defined in AGENTS.md.
 
-1. [CODESTYLE.md](../CODESTYLE.md) is the master code style and formatting authority.
-2. [AGENTS.md](../AGENTS.md) is secondary guidance describing the solution, workflows, and conventions.
-3. Repository configuration files such as [`.editorconfig`](../.editorconfig) and [`.vscode/tasks.json`](../.vscode/tasks.json) define enforced formatting, line endings, and task expectations.
+For language-specific style rules, see:
 
-If any instruction conflicts, follow CODESTYLE.md first, then AGENTS.md.
+- .NET - [`CODESTYLE.md`](../CODESTYLE.md) at the repo root.
 
-## Solution Summary
+Do not duplicate language-specific rules here.
 
-This repository builds and publishes Docker images for Network Optix VMS products (Nx Witness, Nx Meta, Nx Go, DW Spectrum, Wisenet WAVE). It includes base images (nx-base, nx-base-lsio) and derived product images, plus a .NET tooling project that generates Dockerfiles, matrices, and version inputs used by CI and packaging scripts.
+## Commit Messages and Pull Request Titles
 
-### Core Projects
+Feature -> develop PRs squash-merge - the PR title becomes the single commit on develop. Develop -> main PRs merge-commit - main's history shows one merge commit per release with develop's tip as the second parent. Titles are descriptive and have no versioning effect - versioning is handled by [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning) reading [version.json](../version.json) and git history, not by parsing commit messages.
 
-- `CreateMatrix` (.NET 10 console app): Generates Dockerfiles and build matrix data using version and release metadata.
-- `CreateMatrixTests` (xUnit v3 + AwesomeAssertions): Validates release handling and version forwarding.
+`develop` leads `main` by a minor. After a `develop -> main` release lands and main's publish completes, bump the minor in [version.json](../version.json) on `develop` via an isolated `bump-version-X.Y` PR, so develop's prereleases sort above main's last stable. A `develop -> main` promotion that carries only maintenance (not a release) holds main's version instead - `git checkout main -- version.json` on the promotion branch. See [AGENTS.md "Versioning"](../AGENTS.md#versioning).
 
-### Key Inputs and Outputs
+Branch protection enforces the merge method on both bases (develop allows only squash, main allows only merge). When running `gh pr merge` against either base, pick the matching flag (`--squash` for develop, `--merge` for main); a mismatch fails with "Merge method ... is not allowed on this repository". The merge-bot workflow (`.github/workflows/merge-bot-pull-request.yml`) does this dispatch automatically for Dependabot and codegen PRs via a `case` on `base.ref` - keep that pattern when adding new auto-merge jobs.
 
-- Inputs: version and matrix data in `version.json`, [Make/Version.json](../Make/Version.json), and [Make/Matrix.json](../Make/Matrix.json).
-- Outputs: Dockerfiles in [Docker/](../Docker/) (base images and derived product images) and compose/test artifacts in [Make/](../Make/).
-- Templates: Unraid container templates in [Unraid/](../Unraid/).
+### Format
 
-### Build and Validation Workflow (High Level)
+- Imperative subject summarizing the change, <= 72 characters, no trailing period. ("Add 24-hour PM2.5 average sensor", not "Added X" or "Adds X".)
+- Optional body, blank-line separated, explaining *why* the change is being made when that's non-obvious. The diff shows *what*.
 
-- Primary entry points are the `CreateMatrix` CLI commands (version, matrix, make) run directly or via scripts in [Make/](../Make/).
-- Formatting and style verification are enforced by CSharpier and dotnet format, with Husky.Net hooks.
-- The `.Net Format` VS Code task in [`.vscode/tasks.json`](../.vscode/tasks.json) must be clean and warning-free at all times.
+### Rules
 
-### Image Architecture
+- Don't write `update stuff`, `wip`, or other vague titles. (Dependabot's default `Bump X from Y to Z` titles are fine - keep them.)
+- Don't add `Co-Authored-By:` lines unless the user explicitly asks.
+- Don't put release-bump magnitude in the title - no "minor", "patch", "release v0.2.0", etc. NBGV computes the next release version from `version.json` + git history. Dependency versions in dependency-bump titles are fine and expected.
+- Use US English spelling and match the existing heading style of the file you're editing: title case with lowercase short bind words (a, an, the, and, but, or, of, in, on, at, to, by, for, from); hyphenated compounds capitalize both parts unless the second is a short preposition (*Built-in*, *EPA-Corrected*, *24-Hour*).
 
-- Base images (`nx-base`, `nx-base-lsio`) are built and pushed, then used as `FROM` images for derived product Dockerfiles.
-- Derived images should track base image tag changes (for example, the Ubuntu distro tag) to keep builds consistent.
+### Examples
 
-### CI Pipeline (GitHub Actions)
-
-- Pull requests run unit tests and style checks, plus a fast smoke build (NxMeta and NxMeta-LSIO, amd64 only, no push) that runs only when image files change -- not the full matrix.
-- Publishing is schedule/manual only via `publish-release.yml`, which builds the base images once and then publishes the full matrix for both the `main` and `develop` branches in a single run.
-- Merges to `main`/`develop` do not publish; auto-merged Dependabot and codegen PRs are picked up by the next scheduled publish. Do not reintroduce push-triggered publishing or full-matrix PR builds.
-- Structured files are linted in-editor via the extensions recommended in the workspace file `NxWitness.code-workspace` (C#, Markdown, Docker, GitHub Actions, spelling) rather than a CI lint job; lint changed files before pushing, and run `actionlint` for deeper workflow checks. Editor settings, extension recommendations, and spell-check words belong in the workspace file (not `.vscode/`). See AGENTS.md.
-
-## What to Keep in Sync
-
-- Generated Dockerfiles and scripts must reflect CreateMatrix behavior.
-- Base image Dockerfiles and derived image Dockerfiles should remain aligned since derived images build on the base images.
-- Documentation in [README.md](../README.md) and release notes should align with current outputs and supported product variants.
-
-## Expectations for Changes
-
-- Follow the zero-warnings policy and formatting requirements in [CODESTYLE.md](../CODESTYLE.md).
-- Use explicit types (no `var`), Allman braces, file-scoped namespaces, and other conventions as defined in the master style guide.
-- Respect line endings and encoding rules from the repository configuration, including UTF-8 without BOM.
-
-## Versioning
-
-`develop` leads `main` by a minor. After a `develop -> main` release lands and main's publish completes, bump the minor in [version.json](../version.json) on `develop` via an isolated `bump-version-X.Y` PR, so develop's NBGV prerelease version (baked into its images as `LABEL_VERSION`) stays above main's last stable release. A `develop -> main` promotion that carries only maintenance (dependency bumps, CI/doc fixes, template re-syncs) holds main's version instead - `git checkout main -- version.json` on the promotion branch. See [AGENTS.md "Versioning"](../AGENTS.md#versioning).
+```text
+Add structured logging extensions to library
+Pin softprops/action-gh-release to commit SHA
+Drop net8.0 multi-targeting from console project
+Bump xunit.v3 from 3.2.2 to 3.3.0
+Clarify LSIO volume configuration in README
+```
 
 ## GitHub Copilot Review Runbook
+
+> **Carry this runbook verbatim into every derived repo.** This whole file is a drop-in: copy it as-is and change only the `<owner>` / `<repo>` / `<N>` placeholders in the snippets below (and drop the language-specific style pointers that don't apply). It pairs with the [AGENTS.md "PR Review Etiquette"](../AGENTS.md#pr-review-etiquette) contract, which is also a mandatory verbatim carry - see [ProjectTemplate AGENTS.md "Files and Sections Derived Repos Must Carry Verbatim"](https://github.com/ptr727/ProjectTemplate/blob/main/AGENTS.md#files-and-sections-derived-repos-must-carry-verbatim). A derived repo without this runbook in-repo has no pointer to the reliable Copilot mechanics and falls back to known-broken paths (the no-op `POST /requested_reviewers`, the wrong bot-login filter).
 
 Use this section for provider-specific mechanics. The expected review loop *contract* (request review on every push, verify head-SHA coverage, triage findings, reply + resolve, escalate when stuck) is defined in [AGENTS.md -> PR Review Etiquette](../AGENTS.md#pr-review-etiquette). This section only describes how to make GitHub Copilot reliably execute it.
 
@@ -183,3 +166,9 @@ Reply-body conventions:
 - Declined architecture proposal: one-sentence rationale.
 
 After the final push, sweep-resolve stale older threads for removed code paths.
+
+## When in Doubt
+
+Read [AGENTS.md](../AGENTS.md) for the full picture (release flow, files you must not touch, branching, workflow YAML). For language-specific rules, [`CODESTYLE.md`](../CODESTYLE.md) is authoritative. Don't restate any of these files' rules in commit bodies or PR descriptions - keep those focused on the change itself.
+
+**In a derived repo:** if you find a discrepancy that should be fixed in the template itself (this file or AGENTS.md is out of date, a rule is missing, something bit this repo and would bite the next), open an issue upstream in [`ptr727/ProjectTemplate`](https://github.com/ptr727/ProjectTemplate) rather than only fixing it locally - see [ProjectTemplate AGENTS.md "Staying in Sync and Reporting Drift Upstream"](https://github.com/ptr727/ProjectTemplate/blob/main/AGENTS.md#staying-in-sync-and-reporting-drift-upstream).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 Repository conventions for GitHub Copilot (and any other AI agent reading this file).
 
-The **canonical guide is [AGENTS.md](../AGENTS.md)** at the repo root - read it first. It covers project layout, branch flow, PR review etiquette, the release pipeline, workflow YAML conventions, and what NOT to touch.
+The **canonical guide is [AGENTS.md](../AGENTS.md)** at the repo root - read it first. It covers project layout, branch flow, PR review etiquette, the release pipeline, workflow conventions, coding conventions, and notes for changes.
 
 This file is intentionally narrow: commit/PR-title conventions (so VS Code's AI commit-message and PR-title generators get them without an extra fetch), plus a GitHub Copilot Review Runbook that documents the provider-specific mechanics behind the review-loop contract defined in AGENTS.md.
 


### PR DESCRIPTION
Completes the last open item of #418 (realign with `ptr727/ProjectTemplate`). Items 2–5 were already resolved by #422 and the rulesets are correct (`develop` squash-only, `main` merge-only, lowercase names); only `.github/copilot-instructions.md` still diverged.

## Change

Carry the template's whole-file [`.github/copilot-instructions.md`](https://github.com/ptr727/ProjectTemplate/blob/main/.github/copilot-instructions.md) (verbatim drop-in): `# Copilot Instructions` → **Commit Messages and Pull Request Titles** → **GitHub Copilot Review Runbook** (unchanged from #422) → **When in Doubt**. Drops the NxWitness-specific preamble (Purpose, Solution Summary, CI Pipeline, standalone Versioning, etc.) — all already in [AGENTS.md](../blob/develop/AGENTS.md).

### Adaptations (per the carry contract)

- Keep only the .NET `CODESTYLE.md` pointer (drop Python); drop devcontainer mentions (none here).
- Fill `owner`/`repo` as `ptr727`/`NxWitness` in the runbook snippets; keep `<N>` placeholders.
- Retarget AGENTS.md cross-links to this repo's sections (`#release-model` → `#versioning`; keep `#pr-review-etiquette`). The template's "Files…Must Carry Verbatim" and "Staying in Sync" links point upstream, since this repo's AGENTS.md has no equivalent sections.

## Out of scope

Versioning is unchanged — it already matches the template; making it functional is a separate template-level effort.

## Notes

Doc-only, no code. An upstream issue will be filed against `ptr727/ProjectTemplate` re: the carried file linking to AGENTS.md sections a derived repo only has if it also carries the template's AGENTS.md structure.

Closes #418.