### PR TITLE
Bump version to 2.14 and document LSIO permissions fix

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,8 @@ This is a project to build and publish docker images for various [Network Optix]
 
 ## Release History
 
+- Version 2.14:
+  - Fixed an LSIO permissions race where the startup `chown` could run before the `PUID`/`PGID` remap, leaving `/config` and `/media` owned by the wrong user and breaking media writes.
 - Version 2.13:
   - Fixed a regression bug that surfaced when Nx released an older version under the same tag, triggering the version-forward-release only logic.
 - Version 2.12:

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ This is a project to build and publish docker images for various [Network Optix]
 
 ### Release Notes
 
-**Version: 2.13**:
+**Version: 2.14**:
 
 **Summary**:
 
-- Fixed a regression bug that surfaced when Nx released an older version under the same tag, triggering the version-forward-release only logic.
+- Fixed an LSIO permissions race where the startup `chown` could run before the `PUID`/`PGID` remap, leaving `/config` and `/media` owned by the wrong user and breaking media writes.
 
 See [Release History](./HISTORY.md) for complete release notes and older versions.
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.13",
+  "version": "2.14",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
Prep for the 2.14 `develop -> main` release.

- Bump `version.json` NBGV floor 2.13 -> 2.14.
- Add the `Version 2.14` release note to HISTORY.md and the README Release Notes for the LSIO PUID/PGID permission-ordering fix (#450).

🤖 Generated with [Claude Code](https://claude.com/claude-code)