### PR TITLE
Reword diagram-intro sentence for clarity

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -214,7 +214,7 @@ A person steps in only for a breaking change (a red check) or to dispatch a rele
 
 Four diagrams trace the architecture above: the pull-request gate, the self-publisher, the bot
 automation, and the trigger chain that turns a daily codegen run into a published release. They are the
-same outcomes section 4 contracts, drawn from the workflow YAML; if a diagram and a guarantee disagree,
+same outcomes the section 4 contract specifies, drawn from the workflow YAML; if a diagram and a guarantee disagree,
 one of them is a defect. Triggers are blue, gates yellow, durable/published outputs green, and stop/skip
 outcomes red.
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -213,8 +213,7 @@ A person steps in only for a breaking change (a red check) or to dispatch a rele
 ### Flow diagrams
 
 Four diagrams trace the architecture above: the pull-request gate, the self-publisher, the bot
-automation, and the trigger chain that turns a daily codegen run into a published release. They are the
-same outcomes the section 4 contract specifies, drawn from the workflow YAML; if a diagram and a guarantee disagree,
+automation, and the trigger chain that turns a daily codegen run into a published release. They depict the same outcomes that the section 4 contract specifies, drawn from the workflow YAML; if a diagram and a guarantee disagree,
 one of them is a defect. Triggers are blue, gates yellow, durable/published outputs green, and stop/skip
 outcomes red.
 


### PR DESCRIPTION
Fleet-wide polish: reword the diagram-section intro sentence (Copilot flagged the original as garden-path grammar on several repos) to 'the same outcomes the section 4 contract specifies', applied identically across all seven repos for convergence.

markdownlint clean, EOL preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)