### PR TITLE
Remove the blanket artifact-cleanup jobs (D5.5)

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -219,31 +219,3 @@ jobs:
           repository: ${{ matrix.repository }}
           short-description: ${{ github.event.repository.description }}
           readme-filepath: ./README.md
-
-  # Workflow artifacts are an intra-run handoff (durable copies live on the GitHub release and Docker Hub), so
-  # leaving them accumulates against the small account-wide storage quota; delete them once every consumer has
-  # read them. This publisher always publishes when it runs (schedule/push/dispatch only), so always() suffices.
-  cleanup-artifacts:
-    name: Delete workflow artifacts job
-    needs: [build-base, build-docker, github-release, docker-readme]
-    if: always()
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-      - name: Delete workflow artifacts step
-        # continue-on-error: best-effort housekeeping must never red the run, even on an unexpected failure.
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          if ! ids=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts --paginate \
-            --jq '.artifacts[].id'); then
-            echo "::warning::Could not list run artifacts; skipping cleanup (storage may not be freed)."
-            ids=""
-          fi
-          for artifact_id in $ids; do
-            gh api --method DELETE "repos/${{ github.repository }}/actions/artifacts/$artifact_id" \
-              || echo "::warning::Failed to delete artifact $artifact_id; continuing."
-          done

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -123,31 +123,3 @@ jobs:
           exit_on_result "changes" "${{ needs.changes.result }}"
           exit_on_result "validate" "${{ needs.validate.result }}"
           exit_on_result "smoke-build" "${{ needs.smoke-build.result }}"
-
-  # The smoke build runs docker/build-push-action, which can emit a build-record artifact, so this terminal
-  # cleanup deletes the run's artifacts to keep them off the small account-wide storage quota. Independent of
-  # check-workflow-status so housekeeping never gates the required merge check.
-  cleanup-artifacts:
-    name: Delete workflow artifacts job
-    needs: [smoke-build]
-    if: ${{ always() && !github.event.deleted }}
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-      - name: Delete workflow artifacts step
-        # continue-on-error: best-effort housekeeping must never red the run, even on an unexpected failure.
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          if ! ids=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts --paginate \
-            --jq '.artifacts[].id'); then
-            echo "::warning::Could not list run artifacts; skipping cleanup (storage may not be freed)."
-            ids=""
-          fi
-          for artifact_id in $ids; do
-            gh api --method DELETE "repos/${{ github.repository }}/actions/artifacts/$artifact_id" \
-              || echo "::warning::Failed to delete artifact $artifact_id; continuing."
-          done


### PR DESCRIPTION
Brings NxWitness into WORKFLOW.md **D5.5** compliance ("cleanup MUST NOT enumerate and delete the run's whole artifact set").

Both `cleanup-artifacts` jobs used `.artifacts[].id` (blanket delete). NxWitness has **no `upload-artifact` anywhere**, so:
- **publish-release.yml** — the job is dead weight (nothing to clean) *and* a blanket delete. Removed.
- **test-pull-request.yml** — its own comment states it deletes `docker/build-push-action`'s auto-emitted **build-record**, which is precisely the artifact class D5.5 protects. Removed as drift.

**Flagged for your review:** removing the test-job cleanup means build-push-action build-records are kept (reaped by GitHub's default retention) rather than deleted each run. That's the D5.5-intended behavior, but if the account storage quota is a real concern for the matrix's build-record volume, we could instead add `retention-days: 1`-style handling or a documented exception. Your call.

actionlint + editorconfig-checker clean; workflows stay LF.