### PR TITLE
Upload test coverage to Codecov

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -66,6 +66,7 @@ jobs:
     needs: [get-version]
     if: ${{ github.ref_name == 'main' || github.ref_name == 'develop' }}
     uses: ./.github/workflows/validate-task.yml
+    secrets: inherit
     with:
       ref: ${{ github.ref_name == 'main' && needs.get-version.outputs.GitCommitId || github.ref_name }}
 

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -75,6 +75,7 @@ jobs:
     name: Validate job
     if: ${{ !github.event.deleted }}
     uses: ./.github/workflows/validate-task.yml
+    secrets: inherit
 
   # Fast smoke build in place of the full matrix: only runs when image files changed, and builds just NxMeta +
   # NxMeta-LSIO on amd64 (no push). branch targets the pushed branch so a push to develop validates the develop

--- a/.github/workflows/validate-task.yml
+++ b/.github/workflows/validate-task.yml
@@ -44,5 +44,15 @@ jobs:
       - name: Check line endings step
         run: docker run --rm -v "$PWD":/check --workdir /check mstruebing/editorconfig-checker@sha256:67b9e9b16a674e36f7c05919da789f03a01d343ca8423eb8797179399af07c00 # editorconfig-checker v3.4.0
 
+      # --collect drives coverlet.collector to emit Cobertura XML into ./coverage/<guid>/.
       - name: Run unit tests step
-        run: dotnet test
+        run: dotnet test --collect:"XPlat Code Coverage" --results-directory ./coverage
+
+      # Report-only: fail_ci_if_error is false so a Codecov hiccup or an absent token never fails the gate.
+      - name: Upload coverage to Codecov step
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          directory: ./coverage
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/CreateMatrixTests/CreateMatrixTests.csproj
+++ b/CreateMatrixTests/CreateMatrixTests.csproj
@@ -16,6 +16,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="All" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CreateMatrix\CreateMatrix.csproj" />


### PR DESCRIPTION
Collects Cobertura coverage from the CreateMatrix unit tests (`dotnet test --collect:"XPlat Code Coverage"`) and uploads it to Codecov, mirroring the proven PlexCleaner pattern.

- `validate-task.yml`: unit-test step now collects coverage into `./coverage`, followed by a report-only Codecov upload (`fail_ci_if_error: false`, so a Codecov hiccup or absent token never fails the gate).
- `CreateMatrixTests.csproj`: adds the `coverlet.collector` package reference (no central package management in this repo, so the version is inline).
- Both callers of `validate-task.yml` (`test-pull-request.yml`, `publish-release.yml`) now pass `secrets: inherit` so the token reaches the reusable job.

Note: the maintainer must set the `CODECOV_TOKEN` secret in the repository Actions secrets for uploads to authenticate; without it the step is a harmless no-op.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>