### PR TITLE
publish-release: gate the pin-push publish to the codegen App identity (release-model)

### DIFF
--- a/.github/workflows/publish-plan-task.yml
+++ b/.github/workflows/publish-plan-task.yml
@@ -1,0 +1,75 @@
+name: Publish plan task
+
+# Single source of truth for the release-gate decision, reused by every publish-release.yml job so the policy
+# lives here, not scattered across job `if:` conditions. A human PR merge never auto-publishes; a release is a
+# deliberate dispatch, a bot (Dependabot/codegen) code-merge to main, or the Docker weekly schedule.
+#
+# Outputs:
+#   publish - 'true' when this run should publish: a bot-authored push (the codegen App merges every bot PR, so
+#             its identity - or dependabot[bot] - is the gate), a schedule, or a workflow_dispatch of main/develop.
+#             A human push (a merge/promotion to main) or a dispatch from any other branch is 'false'.
+#   stable  - 'true' when the target branch is main (stable channel); main-only jobs gate on publish && stable.
+
+on:
+  workflow_call:
+    inputs:
+      event_name:
+        description: The triggering event (github.event_name).
+        required: true
+        type: string
+      actor:
+        description: The actor that triggered the run (github.actor).
+        required: true
+        type: string
+      ref_name:
+        description: The short ref name (github.ref_name).
+        required: true
+        type: string
+    outputs:
+      publish:
+        description: "'true' when this run should publish."
+        value: ${{ jobs.plan.outputs.publish }}
+      stable:
+        description: "'true' when the target branch is main (stable channel)."
+        value: ${{ jobs.plan.outputs.stable }}
+
+jobs:
+
+  plan:
+    name: Plan release job
+    runs-on: ubuntu-latest
+    outputs:
+      publish: ${{ steps.decide.outputs.publish }}
+      stable: ${{ steps.decide.outputs.stable }}
+
+    steps:
+
+      - name: Decide release plan step
+        id: decide
+        env:
+          EVENT: ${{ inputs.event_name }}
+          ACTOR: ${{ inputs.actor }}
+          REF: ${{ inputs.ref_name }}
+        run: |
+          set -euo pipefail
+          publish=false
+          case "$EVENT" in
+            workflow_dispatch)
+              # A human release: only the long-lived branches publish (a stray feature-branch dispatch is a no-op).
+              [[ "$REF" == "main" || "$REF" == "develop" ]] && publish=true
+              ;;
+            schedule)
+              # Docker weekly refresh (main-only by schedule config).
+              publish=true
+              ;;
+            push)
+              # A human merge never auto-publishes; only a bot merge does. The codegen App merges every
+              # Dependabot/codegen PR, so github.actor is its identity (dependabot[bot] allowed defensively).
+              [[ "$ACTOR" == "ptr727-codegen[bot]" || "$ACTOR" == "dependabot[bot]" ]] && publish=true
+              ;;
+          esac
+          stable=false
+          [[ "$REF" == "main" ]] && stable=true
+          echo "publish=$publish" >> "$GITHUB_OUTPUT"
+          echo "stable=$stable" >> "$GITHUB_OUTPUT"
+          echo "Release plan: event=$EVENT actor=$ACTOR ref=$REF -> publish=$publish stable=$stable"

--- a/.github/workflows/publish-plan-task.yml
+++ b/.github/workflows/publish-plan-task.yml
@@ -9,6 +9,8 @@ name: Publish plan task
 #             its identity - or dependabot[bot] - is the gate), a schedule, or a workflow_dispatch of main/develop.
 #             A human push (a merge/promotion to main) or a dispatch from any other branch is 'false'.
 #   stable  - 'true' when the target branch is main (stable channel); main-only jobs gate on publish && stable.
+#   Both outputs are the strings 'true'/'false' - gate with == 'true'; a bare `if: ${{ needs.plan.outputs.publish }}`
+#   is always truthy (a non-empty string is truthy in an Actions expression).
 #
 # Shared across repo types: a library/package repo triggers only push + dispatch and uses `publish`; a
 # Docker/wrapper repo also triggers the weekly schedule and gates main-only jobs on `stable`. A case a given
@@ -67,9 +69,12 @@ jobs:
               publish=true
               ;;
             push)
-              # A human merge never auto-publishes; only a bot merge does. The codegen App merges every
-              # Dependabot/codegen PR, so github.actor is its identity (dependabot[bot] allowed defensively).
-              [[ "$ACTOR" == "ptr727-codegen[bot]" || "$ACTOR" == "dependabot[bot]" ]] && publish=true
+              # A human merge never auto-publishes; only a bot merge to main does. The codegen App merges every
+              # Dependabot/codegen PR, so github.actor is its identity (dependabot[bot] allowed defensively). The
+              # ref==main guard keeps the task self-contained even if a caller's push trigger is not main-only.
+              if [[ "$REF" == "main" ]] && { [[ "$ACTOR" == "ptr727-codegen[bot]" ]] || [[ "$ACTOR" == "dependabot[bot]" ]]; }; then
+                publish=true
+              fi
               ;;
           esac
           stable=false

--- a/.github/workflows/publish-plan-task.yml
+++ b/.github/workflows/publish-plan-task.yml
@@ -9,6 +9,10 @@ name: Publish plan task
 #             its identity - or dependabot[bot] - is the gate), a schedule, or a workflow_dispatch of main/develop.
 #             A human push (a merge/promotion to main) or a dispatch from any other branch is 'false'.
 #   stable  - 'true' when the target branch is main (stable channel); main-only jobs gate on publish && stable.
+#
+# Shared across repo types: a library/package repo triggers only push + dispatch and uses `publish`; a
+# Docker/wrapper repo also triggers the weekly schedule and gates main-only jobs on `stable`. A case a given
+# caller never triggers (e.g. schedule for a library) is simply inert for it - expected of a single-source task.
 
 on:
   workflow_call:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,8 +7,9 @@ name: Publish project release action
 # develop => :develop). Building only the trigger branch keeps github.ref aligned with the branch being
 # versioned, so NBGV classifies it natively with no cross-branch ref leak.
 #
-# Ordinary code merges do NOT publish: only a matrix pin change (push, branch-filtered to main) or a
-# schedule/dispatch does. develop's daily codegen pin update is sync-only (the push trigger is main-only);
+# Ordinary code merges do NOT publish: only a matrix pin change committed by the codegen App (push, branch-
+# filtered to main, gated to the App identity so a human pin edit does not publish) or a schedule/dispatch does.
+# develop's daily codegen pin update is sync-only (the push trigger is main-only);
 # refresh :develop by dispatching from develop. CI/validation runs separately on push (test-pull-request).
 
 on:
@@ -37,7 +38,9 @@ jobs:
   get-version:
     name: Get version information job
     # Only the long-lived branches publish; a stray dispatch from a feature branch is a no-op.
-    if: ${{ github.ref_name == 'main' || github.ref_name == 'develop' }}
+    if: >-
+      ${{ (github.event_name != 'push' || github.actor == 'ptr727-codegen[bot]' || github.actor == 'dependabot[bot]') &&
+          (github.ref_name == 'main' || github.ref_name == 'develop') }}
     uses: ./.github/workflows/get-version-task.yml
     secrets: inherit
     with:
@@ -48,7 +51,9 @@ jobs:
   # main's published base so it can't overwrite the shared tag.
   build-base:
     name: Build base image job
-    if: ${{ github.ref_name == 'main' }}
+    if: >-
+      ${{ (github.event_name != 'push' || github.actor == 'ptr727-codegen[bot]' || github.actor == 'dependabot[bot]') &&
+          github.ref_name == 'main' }}
     uses: ./.github/workflows/build-base-images-task.yml
     secrets: inherit
     with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,6 +11,9 @@ name: Publish project release action
 # filtered to main, gated to the App identity so a human pin edit does not publish) or a schedule/dispatch does.
 # develop's daily codegen pin update is sync-only (the push trigger is main-only);
 # refresh :develop by dispatching from develop. CI/validation runs separately on push (test-pull-request).
+#
+# The publish/stable decision is computed once by the plan job (publish-plan-task.yml); every job gates on its
+# outputs instead of re-testing event/actor/branch.
 
 on:
   workflow_dispatch:
@@ -32,15 +35,24 @@ concurrency:
 
 jobs:
 
+  # Single source of the release-gate decision (publish? stable?) - every job below gates on its outputs
+  # instead of re-testing event/actor/branch. See publish-plan-task.yml for the policy.
+  plan:
+    name: Plan release job
+    uses: ./.github/workflows/publish-plan-task.yml
+    with:
+      event_name: ${{ github.event_name }}
+      actor: ${{ github.actor }}
+      ref_name: ${{ github.ref_name }}
+
   # Compute the version once from the trigger branch and thread it to every consumer. github.ref already
   # equals the built branch (one branch per run), so NBGV classifies natively - main publishes clean, a
   # develop dispatch publishes a prerelease.
   get-version:
     name: Get version information job
     # Only the long-lived branches publish; a stray dispatch from a feature branch is a no-op.
-    if: >-
-      ${{ (github.event_name != 'push' || github.actor == 'ptr727-codegen[bot]' || github.actor == 'dependabot[bot]') &&
-          (github.ref_name == 'main' || github.ref_name == 'develop') }}
+    needs: [plan]
+    if: ${{ needs.plan.outputs.publish == 'true' }}
     uses: ./.github/workflows/get-version-task.yml
     secrets: inherit
     with:
@@ -51,9 +63,8 @@ jobs:
   # main's published base so it can't overwrite the shared tag.
   build-base:
     name: Build base image job
-    if: >-
-      ${{ (github.event_name != 'push' || github.actor == 'ptr727-codegen[bot]' || github.actor == 'dependabot[bot]') &&
-          github.ref_name == 'main' }}
+    needs: [plan]
+    if: ${{ needs.plan.outputs.publish == 'true' && needs.plan.outputs.stable == 'true' }}
     uses: ./.github/workflows/build-base-images-task.yml
     secrets: inherit
     with:
@@ -68,8 +79,8 @@ jobs:
   # exact commit the images and release are built from.
   validate:
     name: Validate job
-    needs: [get-version]
-    if: ${{ github.ref_name == 'main' || github.ref_name == 'develop' }}
+    needs: [plan, get-version]
+    if: ${{ needs.plan.outputs.publish == 'true' }}
     uses: ./.github/workflows/validate-task.yml
     secrets: inherit
     with:
@@ -77,11 +88,12 @@ jobs:
 
   build-docker:
     name: Build Docker image job
-    needs: [get-version, build-base, validate]
+    needs: [plan, get-version, build-base, validate]
     # always() so the job still runs when build-base is intentionally skipped on a develop dispatch; fail only
     # if a prerequisite actually failed.
     if: >-
       ${{ always()
+      && needs.plan.outputs.publish == 'true'
       && needs.get-version.result == 'success'
       && needs.validate.result == 'success'
       && (needs.build-base.result == 'success' || needs.build-base.result == 'skipped') }}
@@ -104,8 +116,8 @@ jobs:
   # main-only: a develop dispatch publishes images + the :develop tag but cuts no versioned GitHub release.
   github-release:
     name: Publish GitHub release job
-    needs: [get-version, build-docker]
-    if: ${{ github.ref_name == 'main' }}
+    needs: [plan, get-version, build-docker]
+    if: ${{ needs.plan.outputs.publish == 'true' && needs.plan.outputs.stable == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -177,8 +189,8 @@ jobs:
   # repos) for the readme matrix below.
   docker-readme-repos:
     name: Get docker hub readme repositories job
-    needs: [get-version, build-docker]
-    if: ${{ github.ref_name == 'main' }}
+    needs: [plan, get-version, build-docker]
+    if: ${{ needs.plan.outputs.publish == 'true' && needs.plan.outputs.stable == 'true' }}
     runs-on: ubuntu-latest
     outputs:
       repositories: ${{ steps.list.outputs.repositories }}
@@ -203,8 +215,8 @@ jobs:
   # main-only: push the repository overview (README.md) to each Docker Hub repo derived above.
   docker-readme:
     name: Publish docker hub readme job
-    needs: [get-version, docker-readme-repos]
-    if: ${{ github.ref_name == 'main' }}
+    needs: [plan, get-version, docker-readme-repos]
+    if: ${{ needs.plan.outputs.publish == 'true' && needs.plan.outputs.stable == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Part of the fleet release-model change: a human merge never auto-publishes; only a bot (codegen/Dependabot) merge, the weekly Docker schedule, or a manual dispatch does.

NxWitness already publishes only on a **main-only** `Make/Matrix.json` push (+ weekly schedule + dispatch), but that push would also fire for a **human** editing the pin. This gates both entry jobs (`get-version`, `build-base`) so a push publishes only when `github.actor` is the codegen App (`ptr727-codegen[bot]`) / `dependabot[bot]`; a human pin edit skips and the maintainer dispatches. Schedule (weekly base/CVE refresh) and dispatch are unaffected (the gate is `event_name != 'push' || bot`).

Header updated to state the gate. Empirically validated actor values on real runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)