### PR TITLE
conformance: per-surface lint architecture (CI action wrappers, language-only hook, VS Code docker)

### DIFF
--- a/.github/workflows/validate-task.yml
+++ b/.github/workflows/validate-task.yml
@@ -2,8 +2,8 @@ name: Validate task
 
 # The single validation gate, reused by test-pull-request (the required check) and the publisher, so CI and
 # publish run the identical definition. Does not build images.
-# - Lint: Husky (CSharpier + dotnet format style), plus Markdown, spelling, and workflow YAML via pinned action
-#   wrappers, and line endings via editorconfig-checker.
+# - Lint: Husky (CSharpier + dotnet format style), plus Markdown, spelling, workflow YAML, and line endings via
+#   pinned action wrappers.
 # - Test: dotnet test with coverage, uploaded to Codecov (report-only).
 
 on:
@@ -42,8 +42,7 @@ jobs:
           dotnet husky install
           dotnet husky run
 
-      # Doc linters run as pinned action wrappers (Dependabot bumps the SHA). editorconfig-checker has no action, so
-      # it runs via Docker at :latest (Dependabot cannot bump a run-step digest, and a pin would only bitrot).
+      # All doc linters run as pinned action wrappers, which Dependabot bumps.
       - name: Lint Markdown step
         uses: DavidAnson/markdownlint-cli2-action@8de2aa07cae85fd17c0b35642db70cf5495f1d25 # v24.0.0
         with:
@@ -59,7 +58,7 @@ jobs:
         uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
 
       - name: Check line endings step
-        run: docker run --rm -v "$PWD":/check --workdir /check mstruebing/editorconfig-checker:latest
+        uses: editorconfig-checker/action-editorconfig-checker@840e866d93b8e032123c23bac69dece044d4d84c # v2.2.0
 
       # --collect drives coverlet.collector to emit Cobertura XML into ./coverage/<guid>/.
       - name: Run unit tests step

--- a/.github/workflows/validate-task.yml
+++ b/.github/workflows/validate-task.yml
@@ -2,9 +2,9 @@ name: Validate task
 
 # The single validation gate, reused by test-pull-request (the required check) and the publisher, so CI and
 # publish run the identical definition. Does not build images.
-# - Lint: Husky (CSharpier + dotnet format style), Markdown, spelling, workflow YAML, and line endings.
+# - Lint: Husky (CSharpier + dotnet format style), plus Markdown, spelling, and workflow YAML via pinned action
+#   wrappers, and line endings via editorconfig-checker.
 # - Test: dotnet test with coverage, uploaded to Codecov (report-only).
-# - Linter parity: the Docker linters match the editor extensions and the pre-commit hook.
 
 on:
   workflow_call:
@@ -42,15 +42,21 @@ jobs:
           dotnet husky install
           dotnet husky run
 
-      # Docker linters run at :latest, not pinned: Dependabot cannot bump run-step image digests, so a pin only bitrots.
+      # Doc linters run as pinned action wrappers (Dependabot bumps the SHA). editorconfig-checker has no action, so
+      # it runs via Docker at :latest (Dependabot cannot bump a run-step digest, and a pin would only bitrot).
       - name: Lint Markdown step
-        run: docker run --rm -v "$PWD":/workdir davidanson/markdownlint-cli2:latest "**/*.md"
+        uses: DavidAnson/markdownlint-cli2-action@8de2aa07cae85fd17c0b35642db70cf5495f1d25 # v24.0.0
+        with:
+          globs: '**/*.md'
 
       - name: Spell check step
-        run: docker run --rm -v "$PWD":/workdir --workdir /workdir ghcr.io/streetsidesoftware/cspell:latest "**/*.md"
+        uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8.4.0
+        with:
+          files: '**/*.md'
+          incremental_files_only: false
 
       - name: Lint workflows step
-        run: docker run --rm -v "$PWD":/repo --workdir /repo rhysd/actionlint:latest -color
+        uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
 
       - name: Check line endings step
         run: docker run --rm -v "$PWD":/check --workdir /check mstruebing/editorconfig-checker:latest

--- a/.github/workflows/validate-task.yml
+++ b/.github/workflows/validate-task.yml
@@ -42,18 +42,18 @@ jobs:
           dotnet husky install
           dotnet husky run
 
-      # Docker images are digest-pinned (version in the trailing comment) so CI is reproducible.
+      # Docker linters run at :latest, not pinned: Dependabot cannot bump run-step image digests, so a pin only bitrots.
       - name: Lint Markdown step
-        run: docker run --rm -v "$PWD":/workdir davidanson/markdownlint-cli2@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5 "**/*.md" # markdownlint-cli2 v0.22.1
+        run: docker run --rm -v "$PWD":/workdir davidanson/markdownlint-cli2:latest "**/*.md"
 
       - name: Spell check step
-        run: docker run --rm -v "$PWD":/workdir --workdir /workdir ghcr.io/streetsidesoftware/cspell@sha256:cb2eab4ec34956aca554e35615da65401d510fa5983cce2773391e2fd9f4fc20 "**/*.md" # cspell v10.0.1
+        run: docker run --rm -v "$PWD":/workdir --workdir /workdir ghcr.io/streetsidesoftware/cspell:latest "**/*.md"
 
       - name: Lint workflows step
-        run: docker run --rm -v "$PWD":/repo --workdir /repo rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 -color # actionlint v1.7.12
+        run: docker run --rm -v "$PWD":/repo --workdir /repo rhysd/actionlint:latest -color
 
       - name: Check line endings step
-        run: docker run --rm -v "$PWD":/check --workdir /check mstruebing/editorconfig-checker@sha256:67b9e9b16a674e36f7c05919da789f03a01d343ca8423eb8797179399af07c00 # editorconfig-checker v3.4.0
+        run: docker run --rm -v "$PWD":/check --workdir /check mstruebing/editorconfig-checker:latest
 
       # --collect drives coverlet.collector to emit Cobertura XML into ./coverage/<guid>/.
       - name: Run unit tests step

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,7 +3,7 @@
 
 # Local pre-commit: language formatting and style only (no Docker). Full lint runs in CI and the VS Code Lint tasks.
 
-# .NET: CSharpier + dotnet format style via task-runner.json. A Python repo runs ruff here instead.
+# .NET: CSharpier + dotnet format style via Husky.Net. A Python repo runs ruff here instead.
 if command -v dotnet >/dev/null 2>&1; then
     dotnet husky run
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -22,15 +22,15 @@ lint() {
 staged=$(git diff --cached --name-only --diff-filter=ACMR)
 
 # Line endings and charset across the whole tree.
-lint mstruebing/editorconfig-checker@sha256:67b9e9b16a674e36f7c05919da789f03a01d343ca8423eb8797179399af07c00
+lint mstruebing/editorconfig-checker:latest
 
 # Workflow YAML (plus embedded run: shell via bundled shellcheck) when a workflow file is staged.
 if printf '%s\n' "$staged" | grep -Eq '^\.github/workflows/.*\.ya?ml$'; then
-    lint rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 -color
+    lint rhysd/actionlint:latest -color
 fi
 
-# Markdown lint + spelling (word list + exclusions from cspell.json) when a Markdown file is staged.
-if printf '%s\n' "$staged" | grep -q '\.md$'; then
-    lint davidanson/markdownlint-cli2@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5 "**/*.md"
-    lint ghcr.io/streetsidesoftware/cspell@sha256:cb2eab4ec34956aca554e35615da65401d510fa5983cce2773391e2fd9f4fc20 --no-progress "**/*.md"
+# Markdown lint + spelling when Markdown or its lint config is staged (a config-only change still affects every doc).
+if printf '%s\n' "$staged" | grep -qE '\.md$|(^|/)(cspell\.json|\.markdownlint-cli2\.jsonc)$'; then
+    lint davidanson/markdownlint-cli2:latest "**/*.md"
+    lint ghcr.io/streetsidesoftware/cspell:latest --no-progress "**/*.md"
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,4 +4,6 @@
 # Local pre-commit: language formatting and style only (no Docker). Full lint runs in CI and the VS Code Lint tasks.
 
 # .NET: CSharpier + dotnet format style via task-runner.json. A Python repo runs ruff here instead.
-command -v dotnet >/dev/null 2>&1 && dotnet husky run
+if command -v dotnet >/dev/null 2>&1; then
+    dotnet husky run
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,9 +1,7 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-# Local pre-commit: language formatting and style only, kept fast with native tooling (no Docker).
-# Full linting (Markdown, spelling, workflow YAML, line endings) is not run here. It runs in CI (pinned action
-# wrappers) and on demand via the VS Code "Lint" tasks (Docker), so the hook stays simple.
+# Local pre-commit: language formatting and style only (no Docker). Full lint runs in CI and the VS Code Lint tasks.
 
 # .NET: CSharpier + dotnet format style via task-runner.json. A Python repo runs ruff here instead.
 command -v dotnet >/dev/null 2>&1 && dotnet husky run

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,36 +1,9 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-# Local pre-commit lint with the fleet-standard set, so a commit never hits a CI-only lint failure.
-# - Tools: editorconfig-checker (line endings), actionlint, markdownlint, cspell, via Docker for cross-OS parity.
-# - Safe: runs only an already-present image (never pulls), skips when Docker or the image is absent. CI stays the gate.
-# - Warm images once with the VS Code "Lint" tasks. MSYS_NO_PATHCONV fixes the Git Bash bind mount (no-op elsewhere).
+# Local pre-commit: language formatting and style only, kept fast with native tooling (no Docker).
+# Full linting (Markdown, spelling, workflow YAML, line endings) is not run here. It runs in CI (pinned action
+# wrappers) and on demand via the VS Code "Lint" tasks (Docker), so the hook stays simple.
 
-# C# formatting + style (CSharpier + dotnet format) via task-runner.json. .NET repos only, drop this line otherwise.
-dotnet husky run
-
-lint() {
-    image="$1"
-    shift
-    if command -v docker >/dev/null 2>&1 && docker image inspect "$image" >/dev/null 2>&1; then
-        MSYS_NO_PATHCONV=1 docker run --rm -v "$(pwd):/check" -w /check "$image" "$@" || exit 1
-    else
-        echo "husky: $image not available (Docker not running or image absent), skipping - CI enforces it"
-    fi
-}
-
-staged=$(git diff --cached --name-only --diff-filter=ACMR)
-
-# Line endings and charset across the whole tree.
-lint mstruebing/editorconfig-checker:latest
-
-# Workflow YAML (plus embedded run: shell via bundled shellcheck) when a workflow file is staged.
-if printf '%s\n' "$staged" | grep -Eq '^\.github/workflows/.*\.ya?ml$'; then
-    lint rhysd/actionlint:latest -color
-fi
-
-# Markdown lint + spelling when Markdown or its lint config is staged (a config-only change still affects every doc).
-if printf '%s\n' "$staged" | grep -qE '\.md$|(^|/)(cspell\.json|\.markdownlint-cli2\.jsonc)$'; then
-    lint davidanson/markdownlint-cli2:latest "**/*.md"
-    lint ghcr.io/streetsidesoftware/cspell:latest --no-progress "**/*.md"
-fi
+# .NET: CSharpier + dotnet format style via task-runner.json. A Python repo runs ruff here instead.
+command -v dotnet >/dev/null 2>&1 && dotnet husky run

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -119,7 +119,7 @@
         {
             "label": "Lint: Line Endings",
             "type": "shell",
-            "command": "docker run --rm -v \"${workspaceFolder}:/check\" -w /check mstruebing/editorconfig-checker@sha256:67b9e9b16a674e36f7c05919da789f03a01d343ca8423eb8797179399af07c00",
+            "command": "docker run --rm -v \"${workspaceFolder}:/check\" -w /check mstruebing/editorconfig-checker:latest",
             "problemMatcher": [],
             "presentation": {
                 "showReuseMessage": false,
@@ -129,7 +129,7 @@
         {
             "label": "Lint: Workflows",
             "type": "shell",
-            "command": "docker run --rm -v \"${workspaceFolder}:/repo\" -w /repo rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 -color",
+            "command": "docker run --rm -v \"${workspaceFolder}:/repo\" -w /repo rhysd/actionlint:latest -color",
             "problemMatcher": [],
             "presentation": {
                 "showReuseMessage": false,
@@ -139,7 +139,7 @@
         {
             "label": "Lint: Markdown",
             "type": "shell",
-            "command": "docker run --rm -v \"${workspaceFolder}:/workdir\" -w /workdir davidanson/markdownlint-cli2@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5 \"**/*.md\"",
+            "command": "docker run --rm -v \"${workspaceFolder}:/workdir\" -w /workdir davidanson/markdownlint-cli2:latest \"**/*.md\"",
             "problemMatcher": [],
             "presentation": {
                 "showReuseMessage": false,
@@ -149,7 +149,7 @@
         {
             "label": "Lint: Spelling",
             "type": "shell",
-            "command": "docker run --rm -v \"${workspaceFolder}:/workdir\" -w /workdir ghcr.io/streetsidesoftware/cspell@sha256:cb2eab4ec34956aca554e35615da65401d510fa5983cce2773391e2fd9f4fc20 --no-progress \"**/*.md\"",
+            "command": "docker run --rm -v \"${workspaceFolder}:/workdir\" -w /workdir ghcr.io/streetsidesoftware/cspell:latest --no-progress \"**/*.md\"",
             "problemMatcher": [],
             "presentation": {
                 "showReuseMessage": false,

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -114,8 +114,8 @@
                 "clear": false
             }
         },
-        // Lint group - the local full doc-lint surface (Docker at :latest), matching the CI lint set. Run on
-        // demand. The pre-commit hook does language formatting only. Language-agnostic, every repo carries these.
+        // Lint group - the local full doc-lint surface (Docker at :latest), matching the CI lint set.
+        // Run on demand. The pre-commit hook does language formatting only. Every repo carries these.
         {
             "label": "Lint: Line Endings",
             "type": "shell",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -114,8 +114,8 @@
                 "clear": false
             }
         },
-        // Lint group - runs the fleet-standard lint set locally and warms
-        // the Docker images the .husky/pre-commit hook reuses. Language-agnostic; every repo carries these.
+        // Lint group - the local full doc-lint surface (Docker at :latest), matching the CI lint set. Run on
+        // demand. The pre-commit hook does language formatting only. Language-agnostic, every repo carries these.
         {
             "label": "Lint: Line Endings",
             "type": "shell",


### PR DESCRIPTION
Follow-up to #499, mirroring ProjectTemplate #276. Adopts the fleet lint architecture: the tool that fits each surface instead of docker-run on all three.

- `validate-task.yml`: markdownlint, cspell, actionlint run as **pinned action wrappers** (Dependabot-bumped); editorconfig-checker also runs via its action wrapper, so all four CI linters are pinned actions.
- `.husky/pre-commit`: **language formatting/style only** (`dotnet husky run`) — no Docker, no doc linters. Simpler and faster.
- `.vscode/tasks.json`: keeps the full doc-lint set via docker `:latest` for on-demand local linting.

Supersedes this PR's earlier `:latest`-docker-everywhere approach. All linters pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)