### PR TITLE
fix: run editorconfig-checker via Docker (its action is setup-only)

### DIFF
--- a/.github/workflows/validate-task.yml
+++ b/.github/workflows/validate-task.yml
@@ -2,8 +2,8 @@ name: Validate task
 
 # The single validation gate, reused by test-pull-request (the required check) and the publisher, so CI and
 # publish run the identical definition. Does not build images.
-# - Lint: Husky (CSharpier + dotnet format style), plus Markdown, spelling, workflow YAML, and line endings via
-#   pinned action wrappers.
+# - Lint: Husky (CSharpier + dotnet format style), plus Markdown, spelling, and workflow YAML via pinned action
+#   wrappers, and line endings via editorconfig-checker (Docker).
 # - Test: dotnet test with coverage, uploaded to Codecov (report-only).
 
 on:
@@ -42,7 +42,8 @@ jobs:
           dotnet husky install
           dotnet husky run
 
-      # All doc linters run as pinned action wrappers, which Dependabot bumps.
+      # The doc linters run as pinned action wrappers (Dependabot bumps them). editorconfig-checker's action only
+      # installs the CLI, so it runs via Docker :latest instead (one step that actually performs the check).
       - name: Lint Markdown step
         uses: DavidAnson/markdownlint-cli2-action@8de2aa07cae85fd17c0b35642db70cf5495f1d25 # v24.0.0
         with:
@@ -58,7 +59,7 @@ jobs:
         uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
 
       - name: Check line endings step
-        uses: editorconfig-checker/action-editorconfig-checker@840e866d93b8e032123c23bac69dece044d4d84c # v2.2.0
+        run: docker run --rm -v "$PWD":/check --workdir /check mstruebing/editorconfig-checker:latest
 
       # --collect drives coverlet.collector to emit Cobertura XML into ./coverage/<guid>/.
       - name: Run unit tests step

--- a/.github/workflows/validate-task.yml
+++ b/.github/workflows/validate-task.yml
@@ -42,8 +42,7 @@ jobs:
           dotnet husky install
           dotnet husky run
 
-      # The doc linters run as pinned action wrappers (Dependabot bumps them). editorconfig-checker's action only
-      # installs the CLI, so it runs via Docker :latest instead (one step that actually performs the check).
+      # Doc linters run as pinned action wrappers. editorconfig-checker's action is install-only, so it runs via Docker.
       - name: Lint Markdown step
         uses: DavidAnson/markdownlint-cli2-action@8de2aa07cae85fd17c0b35642db70cf5495f1d25 # v24.0.0
         with:


### PR DESCRIPTION
**Bug:** `editorconfig-checker/action-editorconfig-checker` only installs the CLI (its README example adds a separate run step). #500 used `uses:` with no run step, so the "Check line endings" step passed **without validating line endings** on develop.

**Fix:** revert to the Docker invocation, which runs the check in one step (and matches the VS Code Lint task). Header comment updated.

Mirrors ProjectTemplate #279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)