### PR TITLE
lint: split semicolon run-ons in comments into clean sentences

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -37,7 +37,7 @@ end_of_line = crlf
 indent_size = 2
 
 # Workflow YAML is LF: Dependabot and Actions rewrite it with LF, so declaring LF keeps it consistent instead of
-# mixed. git still leaves endings alone (`* -text`); this and CI (editorconfig-checker) enforce it. Other YAML is CRLF.
+# mixed. git still leaves endings alone (`* -text`). This and CI (editorconfig-checker) enforce it. Other YAML is CRLF.
 [.github/workflows/*.{yml,yaml}]
 end_of_line = lf
 
@@ -53,14 +53,14 @@ end_of_line = lf
 [*.{cmd,bat,ps1}]
 end_of_line = crlf
 
-# --- .NET-only below: C# and ReSharper style. Everything above is the line-ending
-# governance every derived repo carries; a non-.NET repo may drop from here down. ---
+# .NET-only below: C# and ReSharper style. Everything above is the line-ending governance
+# every derived repo carries. A non-.NET repo may drop from here down.
 
 # C# files
 [*.cs]
 end_of_line = crlf
 # Suppressions follow CODESTYLE.md "Analyzer Diagnostics and Suppressions": prefer a
-# [SuppressMessage] attribute or the owning project's .editorconfig; relax a rule
+# [SuppressMessage] attribute or the owning project's .editorconfig. Relax a rule
 # repo-wide here only when it applies to every project (never a brownfield batch).
 dotnet_diagnostic.IDE0055.severity = none
 dotnet_analyzer_diagnostic.severity = suggestion

--- a/.github/workflows/build-docker-task.yml
+++ b/.github/workflows/build-docker-task.yml
@@ -19,7 +19,7 @@ on:
       # registry buildcache tag to use. Decoupled from `ref` so `ref` can be pinned to an
       # immutable commit (e.g. the publisher pins main to the versioned SHA)
       # while this still selects the right branch's rows. Empty in smoke mode
-      # builds both branches' rows; the publisher passes main and develop so
+      # builds both branches' rows. The publisher passes main and develop so
       # both branches' tags are produced from one scheduled run. Empty in a
       # non-smoke build falls back to github.ref_name for the buildcache tag.
       branch:
@@ -77,10 +77,10 @@ jobs:
           # shellcheck disable=SC2016
           if [[ "$SMOKE" == "true" ]]; then
             # One Ubuntu + one LSIO variant exercises the shared Dockerfile
-            # build logic and the branch's build args; tags are irrelevant
+            # build logic and the branch's build args. Tags are irrelevant
             # since smoke never pushes. Restrict to the PR base branch ($b)
             # so a PR onto develop validates the develop rows and a PR onto
-            # main validates the main rows; empty $b builds both branches.
+            # main validates the main rows. Empty $b builds both branches.
             FILTER='.Images |= (map(select((.Name == "NxMeta" or .Name == "NxMeta-LSIO") and ($b == "" or .Branch == $b))) | unique_by([.Name, .Branch]))'
           elif [[ -n "$BRANCH" ]]; then
             # Publish: build only the rows targeting the branch being built
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [get-matrix, build-base]
     # always() so the job still runs when build-base is intentionally
-    # skipped (build_base == false); fail only if a prerequisite failed.
+    # skipped (build_base == false). Fail only if a prerequisite failed.
     if: >-
       ${{ always()
       && needs.get-matrix.result == 'success'
@@ -118,7 +118,7 @@ jobs:
         images: ${{ fromJson(needs.get-matrix.outputs.matrix).Images }}
 
     env:
-      # Multi-arch (amd64+arm64) only on a full main publish; smoke and develop build amd64 only.
+      # Multi-arch (amd64+arm64) only on a full main publish. Smoke and develop build amd64 only.
       PLATFORMS: ${{ (!inputs.smoke && inputs.branch == 'main') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
 
     steps:

--- a/.github/workflows/get-version-task.yml
+++ b/.github/workflows/get-version-task.yml
@@ -3,7 +3,7 @@ name: Get version information task
 on:
   workflow_call:
     inputs:
-      # Git ref to check out and version. Empty falls back to the caller's default checkout ref (`github.ref`); the
+      # Git ref to check out and version. Empty falls back to the caller's default checkout ref (`github.ref`). The
       # publisher passes an explicit branch so a scheduled run can still compute versions for `develop`.
       ref:
         required: false

--- a/.github/workflows/merge-bot-pull-request.yml
+++ b/.github/workflows/merge-bot-pull-request.yml
@@ -1,6 +1,6 @@
 name: Merge bot pull request action
 
-# Enable auto-merge once per PR on opened/reopened; disable it when a maintainer pushes to a bot branch. Merge
+# Enable auto-merge once per PR on opened/reopened. Disable it when a maintainer pushes to a bot branch. Merge
 # method by base branch (develop = squash, main = merge). App token so the merge fires downstream workflows
 # (GITHUB_TOKEN pushes don't) and so the disable job has write access on read-only Dependabot PRs.
 
@@ -12,7 +12,7 @@ on:
     types: [opened, reopened, synchronize]
 
 # Per-PR group: under `pull_request_target` `github.ref` is the base branch, which would serialize every bot PR
-# against that base; key on the PR number so each PR's events queue independently. `cancel-in-progress: false` so a
+# against that base. Key on the PR number so each PR's events queue independently. `cancel-in-progress: false` so a
 # follow-up synchronize doesn't cancel an in-flight `opened` run before it enables auto-merge.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -47,7 +47,7 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      # Skip semver-major NuGet bumps so they land via human review; other ecosystems' majors auto-merge.
+      # Skip semver-major NuGet bumps so they land via human review. Other ecosystems' majors auto-merge.
       - name: Merge pull request step
         if: >-
           (steps.metadata.outputs.package-ecosystem != 'nuget') ||
@@ -117,7 +117,7 @@ jobs:
     name: Disable auto-merge on maintainer push job
     runs-on: ubuntu-latest
     # Fires when a maintainer pushes to a bot's branch (synchronize, actor != bot). Disables auto-merge so the
-    # maintainer's commits don't merge with the bot's; they re-enable it manually. The disable call is idempotent.
+    # maintainer's commits don't merge with the bot's. They re-enable it manually. The disable call is idempotent.
     if: >-
       github.event.action == 'synchronize' &&
       github.event.pull_request.head.repo.full_name == github.repository &&

--- a/.github/workflows/publish-plan-task.yml
+++ b/.github/workflows/publish-plan-task.yml
@@ -1,18 +1,18 @@
 name: Publish plan task
 
 # Single source of truth for the release-gate decision, reused by every publish-release.yml job so the policy
-# lives here, not scattered across job `if:` conditions. A human PR merge never auto-publishes; a release is a
+# lives here, not scattered across job `if:` conditions. A human PR merge never auto-publishes. A release is a
 # deliberate dispatch, a bot (Dependabot/codegen) code-merge to main, or the Docker weekly schedule.
 #
 # Outputs:
 #   publish - 'true' when this run should publish: a bot-authored push (the codegen App merges every bot PR, so
 #             its identity - or dependabot[bot] - is the gate), a schedule, or a workflow_dispatch of main/develop.
 #             A human push (a merge/promotion to main) or a dispatch from any other branch is 'false'.
-#   stable  - 'true' when the target branch is main (stable channel); main-only jobs gate on publish && stable.
-#   Both outputs are the strings 'true'/'false' - gate with == 'true'; a bare `if: ${{ needs.plan.outputs.publish }}`
+#   stable  - 'true' when the target branch is main (stable channel). Main-only jobs gate on publish && stable.
+#   Both outputs are the strings 'true'/'false' - gate with == 'true'. A bare `if: ${{ needs.plan.outputs.publish }}`
 #   is always truthy (a non-empty string is truthy in an Actions expression).
 #
-# Shared across repo types: a library/package repo triggers only push + dispatch and uses `publish`; a
+# Shared across repo types: a library/package repo triggers only push + dispatch and uses `publish`. A
 # Docker/wrapper repo also triggers the weekly schedule and gates main-only jobs on `stable`. A case a given
 # caller never triggers (e.g. schedule for a library) is simply inert for it - expected of a single-source task.
 
@@ -69,7 +69,7 @@ jobs:
               publish=true
               ;;
             push)
-              # A human merge never auto-publishes; only a bot merge to main does. The codegen App merges every
+              # A human merge never auto-publishes. Only a bot merge to main does. The codegen App merges every
               # Dependabot/codegen PR, so github.actor is its identity (dependabot[bot] allowed defensively). The
               # ref==main guard keeps the task self-contained even if a caller's push trigger is not main-only.
               if [[ "$REF" == "main" ]] && { [[ "$ACTOR" == "ptr727-codegen[bot]" ]] || [[ "$ACTOR" == "dependabot[bot]" ]]; }; then

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,10 +9,10 @@ name: Publish project release action
 #
 # Ordinary code merges do NOT publish: only a matrix pin change committed by the codegen App (push, branch-
 # filtered to main, gated to the App identity so a human pin edit does not publish) or a schedule/dispatch does.
-# develop's daily codegen pin update is sync-only (the push trigger is main-only);
-# refresh :develop by dispatching from develop. CI/validation runs separately on push (test-pull-request).
+# develop's daily codegen pin update is sync-only (the push trigger is main-only).
+# Refresh :develop by dispatching from develop. CI/validation runs separately on push (test-pull-request).
 #
-# The publish/stable decision is computed once by the plan job (publish-plan-task.yml); every job gates on its
+# The publish/stable decision is computed once by the plan job (publish-plan-task.yml). Every job gates on its
 # outputs instead of re-testing event/actor/branch.
 
 on:
@@ -20,7 +20,7 @@ on:
   schedule:
     # Weekly rebuild/publish of main (Mon 02:00 UTC) to pick up shared base-image updates.
     - cron: '0 2 * * MON'
-  # Publish main immediately when the codegen matrix changes; the daily codegen commits the new pin here.
+  # Publish main immediately when the codegen matrix changes. The daily codegen commits the new pin here.
   push:
     branches: [main]
     paths: [Make/Matrix.json]
@@ -50,7 +50,7 @@ jobs:
   # develop dispatch publishes a prerelease.
   get-version:
     name: Get version information job
-    # Only the long-lived branches publish; a stray dispatch from a feature branch is a no-op.
+    # Only the long-lived branches publish. A stray dispatch from a feature branch is a no-op.
     needs: [plan]
     if: ${{ needs.plan.outputs.publish == 'true' }}
     uses: ./.github/workflows/get-version-task.yml
@@ -59,7 +59,7 @@ jobs:
       ref: ${{ github.ref_name }}
 
   # Base images share a single tag (nx-base:ubuntu-noble) across branches. The main schedule/push/dispatch
-  # builds and refreshes it; a develop dispatch sets build_base: false (see build-docker below) and reuses
+  # builds and refreshes it. A develop dispatch sets build_base: false (see build-docker below) and reuses
   # main's published base so it can't overwrite the shared tag.
   build-base:
     name: Build base image job
@@ -89,7 +89,7 @@ jobs:
   build-docker:
     name: Build Docker image job
     needs: [plan, get-version, build-base, validate]
-    # always() so the job still runs when build-base is intentionally skipped on a develop dispatch; fail only
+    # always() so the job still runs when build-base is intentionally skipped on a develop dispatch. Fail only
     # if a prerequisite actually failed.
     if: >-
       ${{ always()
@@ -131,7 +131,7 @@ jobs:
           ref: ${{ needs.get-version.outputs.GitCommitId }}
 
       # Backstop (main only): a public release must not carry a prerelease '-', guarding against NBGV mis-versioning the
-      # public ref into a malformed "Latest" release. Strip '+buildmetadata' first - a '-' there is legitimate; only a
+      # public ref into a malformed "Latest" release. Strip '+buildmetadata' first - a '-' there is legitimate. Only a
       # '-' in the core/prerelease segment marks a prerelease.
       - name: Verify public release version step
         env:

--- a/.github/workflows/run-codegen-pull-request-task.yml
+++ b/.github/workflows/run-codegen-pull-request-task.yml
@@ -20,7 +20,7 @@ jobs:
       contents: write
       pull-requests: write
     strategy:
-      # Each branch gets its own parallel codegen run + PR; one branch's failure doesn't affect the other.
+      # Each branch gets its own parallel codegen run + PR. One branch's failure doesn't affect the other.
       fail-fast: false
       matrix:
         target:

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -2,7 +2,7 @@ name: Test pull request action
 
 # CI for every branch. Runs on push so the reusable tasks resolve from the pushed head: a PR that edits a
 # workflow tests its own copy, and the aggregator (the ruleset required check) is produced on the head SHA by
-# the sole producing run. validate (unit tests + lint) runs on every push; the image smoke build runs only
+# the sole producing run. validate (unit tests + lint) runs on every push. The image smoke build runs only
 # when image files changed (inline git diff change-gate), since a full product smoke is heavier than a
 # doc-only push warrants. CI never publishes (the publisher runs on schedule/push-on-Matrix.json/dispatch).
 #
@@ -23,7 +23,7 @@ concurrency:
 jobs:
 
   # Inline change-gate (no third-party action): diff the push against its before-commit to decide whether the
-  # image smoke build is needed. image => any Docker/Matrix/Version file changed; base => a base Dockerfile
+  # image smoke build is needed. image => any Docker/Matrix/Version file changed. Base => a base Dockerfile
   # changed. On a non-push event (workflow_dispatch) or a new branch (no before-commit), build everything.
   # !github.event.deleted skips a branch-deletion push (github.sha is all-zeros, so checkout would fail).
   changes:
@@ -47,14 +47,14 @@ jobs:
           AFTER: ${{ github.sha }}
         run: |
           set -euo pipefail
-          # A new branch or non-push event has no usable before-commit (all-zeros or empty); build everything.
+          # A new branch or non-push event has no usable before-commit (all-zeros or empty). Build everything.
           if [[ "$BEFORE" =~ ^0+$ || -z "$BEFORE" || "${{ github.event_name }}" != "push" ]]; then
             echo "image=true" >> "$GITHUB_OUTPUT"
             echo "base=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if ! DIFF=$(git diff --name-only "$BEFORE" "$AFTER" 2>/dev/null); then
-            # BEFORE is not in the fetched history (e.g. a force-push that rewrote it); build everything.
+            # BEFORE is not in the fetched history (e.g. a force-push that rewrote it). Build everything.
             echo "image=true" >> "$GITHUB_OUTPUT"
             echo "base=true" >> "$GITHUB_OUTPUT"
             exit 0
@@ -93,7 +93,7 @@ jobs:
     with:
       push: false
       smoke: true
-      # Map the push ref to a Matrix.json .Branch value: a main push checks main's rows; every other branch
+      # Map the push ref to a Matrix.json .Branch value: a main push checks main's rows. Every other branch
       # (develop, and feature branches that merge via develop) FALLS BACK to develop's rows. Passing
       # github.ref_name directly would be a feature-branch name matching no .Branch row -> empty smoke matrix.
       branch: ${{ github.ref_name == 'main' && 'main' || 'develop' }}
@@ -112,7 +112,7 @@ jobs:
         run: |
           set -euo pipefail
           exit_on_result() {
-            # Pass on success or skipped (smoke-build is skipped when no image files changed); fail only on
+            # Pass on success or skipped (smoke-build is skipped when no image files changed). Fail only on
             # failure/cancelled.
             if [[ "$2" == "failure" || "$2" == "cancelled" ]]; then
               echo "::error::Job '$1' failed or was cancelled."

--- a/CreateMatrix/ProductInfo.cs
+++ b/CreateMatrix/ProductInfo.cs
@@ -82,8 +82,8 @@ internal sealed class ProductInfo
         };
 
     // Dockerfile name, excluding the .Dockerfile extension.
-    // This is the single source of the image/Dockerfile naming convention; ImageInfo derives its
-    // name from here. The base variant is a bool (Ubuntu vs LSIO); promote it to an enum only if a
+    // This is the single source of the image/Dockerfile naming convention. ImageInfo derives its
+    // name from here. The base variant is a bool (Ubuntu vs LSIO). Promote it to an enum only if a
     // third base type is ever added (which would also ripple through ComposeFile/DockerFile).
     public static string GetDocker(ProductType productType, bool lsio) =>
         $"{productType}{(lsio ? "-LSIO" : "")}";

--- a/CreateMatrix/ReleaseVersionForward.cs
+++ b/CreateMatrix/ReleaseVersionForward.cs
@@ -28,7 +28,7 @@ internal static class ReleaseVersionForward
         VersionInfo.LabelType label
     )
     {
-        // NOTE: Forward-only is intentional; a published tag must not regress to a lesser version.
+        // NOTE: Forward-only is intentional. A published tag must not regress to a lesser version.
         // If a label is released, then pulled, then re-released with a lesser version, we keep the
         // old (higher) version. This is harmless while the old build is still downloadable, and if
         // its files were actually removed the run fails loudly in VerifyUrlsAsync (404) for a human


### PR DESCRIPTION
Comment-hygiene sweep (no semicolons in comments). The semicolon sentence-connectors across the workflow files, `.editorconfig`, and two C# files are replaced with proper sentence breaks — split into two sentences, not just deleted (which had produced run-ons before). Also drops a stray `---` divider decoration in `.editorconfig`.

- 7 workflow files, `.editorconfig`, `ProductInfo.cs`, `ReleaseVersionForward.cs`
- **Pure comment changes, no behavior change** (verified: no non-comment lines added/removed)
- actionlint + editorconfig-checker clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)