### PR TITLE
lint: --pull=always on Lint tasks + Lint: Spelling to README+HISTORY

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -120,7 +120,7 @@
             "label": "Lint: EditorConfig",
             "type": "process",
             "command": "docker",
-            "args": [ "run", "--rm", "-v", "${workspaceFolder}:/check", "-w", "/check", "mstruebing/editorconfig-checker:latest" ],
+            "args": [ "run", "--rm", "--pull=always", "-v", "${workspaceFolder}:/check", "-w", "/check", "mstruebing/editorconfig-checker:latest" ],
             "problemMatcher": [],
             "presentation": {
                 "showReuseMessage": false,
@@ -131,7 +131,7 @@
             "label": "Lint: Workflows",
             "type": "process",
             "command": "docker",
-            "args": [ "run", "--rm", "-v", "${workspaceFolder}:/repo", "-w", "/repo", "rhysd/actionlint:latest", "-color" ],
+            "args": [ "run", "--rm", "--pull=always", "-v", "${workspaceFolder}:/repo", "-w", "/repo", "rhysd/actionlint:latest", "-color" ],
             "problemMatcher": [],
             "presentation": {
                 "showReuseMessage": false,
@@ -142,7 +142,7 @@
             "label": "Lint: Markdown",
             "type": "process",
             "command": "docker",
-            "args": [ "run", "--rm", "-v", "${workspaceFolder}:/workdir", "-w", "/workdir", "davidanson/markdownlint-cli2:latest", "**/*.md" ],
+            "args": [ "run", "--rm", "--pull=always", "-v", "${workspaceFolder}:/workdir", "-w", "/workdir", "davidanson/markdownlint-cli2:latest", "**/*.md" ],
             "problemMatcher": [],
             "presentation": {
                 "showReuseMessage": false,
@@ -153,7 +153,7 @@
             "label": "Lint: Spelling",
             "type": "process",
             "command": "docker",
-            "args": [ "run", "--rm", "-v", "${workspaceFolder}:/workdir", "-w", "/workdir", "ghcr.io/streetsidesoftware/cspell:latest", "--no-progress", "**/*.md" ],
+            "args": [ "run", "--rm", "--pull=always", "-v", "${workspaceFolder}:/workdir", "-w", "/workdir", "ghcr.io/streetsidesoftware/cspell:latest", "--no-progress", "README.md", "HISTORY.md" ],
             "problemMatcher": [],
             "presentation": {
                 "showReuseMessage": false,


### PR DESCRIPTION
Applies the fleet standard from ProjectTemplate #284: the local docker `Lint:` tasks get `--pull=always` so a local run always uses the current `:latest` image instead of a stale cached one. CI is unaffected (ephemeral runners already pull fresh).

Also normalizes the `Lint: Spelling` task from `**/*.md` to `README.md HISTORY.md` (CI parity per ProjectTemplate #284); broad live spell-checking remains the cspell extension's job.