### PR TITLE
Scope CI spell-check to README and HISTORY

### DIFF
--- a/.github/workflows/validate-task.yml
+++ b/.github/workflows/validate-task.yml
@@ -51,7 +51,9 @@ jobs:
       - name: Spell check step
         uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8.4.0
         with:
-          files: '**/*.md'
+          files: |
+            README.md
+            HISTORY.md
           incremental_files_only: false
 
       - name: Lint workflows step


### PR DESCRIPTION
Narrows the CI cspell (spell-check) step in `.github/workflows/validate-task.yml` from all markdown (`**/*.md`) to just `README.md` + `HISTORY.md`.

Matches the template default in ptr727/ProjectTemplate#302: spell-checking every markdown file forces endlessly padding `cspell.json` with technical terms. Restricting the gate to the two files every repo visitor sees keeps CI meaningful, while broad live spell-checking stays the editor extension's job.

- markdownlint stays repo-wide (`**/*.md`) - unchanged.
- Local `actionlint` (rhysd/actionlint:latest) is clean, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)