### PR TITLE
Scope CI spell-check to README + HISTORY (main-only)

### DIFF
--- a/.github/workflows/validate-task.yml
+++ b/.github/workflows/validate-task.yml
@@ -51,7 +51,9 @@ jobs:
       - name: Spell check step
         uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8.4.0
         with:
-          files: '**/*.md'
+          files: |
+            README.md
+            HISTORY.md
           incremental_files_only: false
 
       - name: Lint workflows step


### PR DESCRIPTION
Cherry-picks the CI cspell-scope fix onto main, without dragging the other in-flight work currently on develop.

This narrows the CI spell-check on **main** from all markdown (`**/*.md`) **to** README.md + HISTORY.md, matching template PR ptr727/ProjectTemplate#302. markdownlint stays repo-wide. The same change is already on develop; this is the surgical main-only path so the feature/dependency work on develop is not promoted with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)