### PR TITLE
Re-vendor the markdownlint config to the current canonical

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,10 +1,13 @@
 {
     "config": {
-        // Prose paragraphs and data-heavy tables/URLs are intentionally long;
-        // reflowing at 80 cols hurts readability and churns diffs.
+        // Prose paragraphs and data-heavy tables or URLs are intentionally long.
+        // Reflowing at 80 columns hurts readability and churns diffs.
         "MD013": false,
-        // Inline HTML is used for reference-link section dividers.
-        "MD033": false,
+        // MD033 (inline HTML) stays enabled so native markdown wins.
+        // HTML comments, used as reference-link dividers, pass it.
+        // The details and summary elements are allowed for GitHub collapsibles, which have no markdown equivalent.
+        // Every other element still flags.
+        "MD033": { "allowed_elements": ["details", "summary"] },
         // Require fenced code blocks over the legacy 4-space-indented style.
         "MD046": { "style": "fenced" },
         // MD060 (table column style) is not enforced - allow both compact


### PR DESCRIPTION
`.markdownlint-cli2.jsonc` is carried `verbatim` from ptr727/ProjectTemplate, so a copy that differs is drift rather than a choice. The hub's regenerated fleet divergence report lists this repo for it.

The canonical enables `MD033` with `details` and `summary` allowed, which is a behavior change rather than a comment sweep. Verified rather than assumed: `markdownlint-cli2` over `**/*.md` reports **0 issues** here under the restored config.

Line endings preserved.

**`repo-config/configure.sh` is deliberately not in this pull request**, though it is also stale. The hub's divergence ledger records that this repo may legitimately keep a thin repo-specific wrapper for its hardcoded Docker Hub secret checks, which the repo-agnostic canonical leaves as a manual-verify note. Overwriting it with the canonical would silently drop that, so it needs a read of what the wrapper does before it is replaced, rather than a copy.

Not in this PR either: `dotnet_analyzer_diagnostic.severity = suggestion` in `.editorconfig`, which gets its own pull request with a build behind it.

Part of the fleet re-vendor sweep tracked in the hub's `TODO.md`.
