### PR TITLE
Migrate testing to native Microsoft.Testing.Platform and update test packages

### DIFF
--- a/.github/workflows/validate-task.yml
+++ b/.github/workflows/validate-task.yml
@@ -62,9 +62,18 @@ jobs:
       - name: Check EditorConfig step
         run: docker run --rm -v "$PWD":/check --workdir /check mstruebing/editorconfig-checker:latest
 
-      # --collect drives coverlet.collector to emit Cobertura XML into ./coverage/<guid>/.
+      # global.json opts into the native Microsoft.Testing.Platform runner, so the VSTest bridge
+      # (and its --collect data collector) is gone.
+      # --coverage-output stays unset because pinning one filename gives every test project in the solution the same path, and the last to finish overwrites the rest.
+      # The default <guid>.cobertura.xml written instead is a name codecov-cli's finder does not match, so each report is prefixed rather than renamed, keeping the guid that makes it unique.
       - name: Run unit tests step
-        run: dotnet test --collect:"XPlat Code Coverage" --results-directory ./coverage
+        run: |
+          set -Eeuo pipefail
+          dotnet test --coverage --coverage-output-format cobertura --results-directory ./coverage
+          for report in ./coverage/*.cobertura.xml; do
+            [ -e "$report" ] || continue
+            mv "$report" "./coverage/coverage-$(basename "$report")"
+          done
 
       # Report-only: fail_ci_if_error is false so a Codecov hiccup or an absent token never fails the gate.
       - name: Upload coverage to Codecov step

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@
 .artifacts
 .DS_Store
 *.user
+
+# Coverage output (dotnet Microsoft.Testing.Extensions.CodeCoverage)
+coverage/
+[Tt]est[Rr]esults/
+*.cobertura.xml
+*.coverage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,12 @@ For comprehensive coding and formatting standards, follow:
   - `version --versionpath=./Make/Version.json`.
   - `matrix --versionpath=./Make/Version.json --matrixpath=./Make/Matrix.json --updateversion`.
   - `make --versionpath=./Make/Version.json --makedirectory=./Make --dockerdirectory=./Docker --versionlabel=Beta`.
+- Tests run on the native Microsoft.Testing.Platform runner, opted into by `global.json`. Locally that is
+  plain `dotnet test`; CI adds coverage with
+  `dotnet test --coverage --coverage-output-format cobertura --results-directory ./coverage`, then prefixes
+  each report to `coverage-<guid>.cobertura.xml` so codecov-cli's file finder matches it. Running an
+  MTP-based test project through the VSTest target is what fails, so the old
+  `--collect:"XPlat Code Coverage"` form is an error here specifically because this project opted in.
 - Formatting and style checks are enforced by Husky.Net and VS Code tasks.
 - Required tasks are documented in `CODESTYLE.md` and `.husky/task-runner.json`.
 - C# code should be formatted with CSharpier, then verified with `dotnet format` (style).

--- a/CreateMatrixTests/CreateMatrixTests.csproj
+++ b/CreateMatrixTests/CreateMatrixTests.csproj
@@ -8,18 +8,14 @@
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AwesomeAssertions" Version="9.5.0" />
+    <PackageReference Include="AwesomeAssertions" Version="9.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.analyzers" Version="1.27.0">
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
+    <PackageReference Include="xunit.analyzers" Version="2.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="All" />
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CreateMatrix\CreateMatrix.csproj" />

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}


### PR DESCRIPTION
Unblocks the Dependabot nuget PRs (#545, #546) and every later nuget bump.

Stacked on #547, so this PR is based on `resync/eol-lf` and will retarget to
`develop` automatically once #547 merges. Its own diff is the five files below.

> Reworked after ptr727/ProjectTemplate#1111 merged. The first revision used
> `coverlet.MTP`, which was the open recommendation at the time. The hub has since
> settled WORKFLOW.md D1.6 on `Microsoft.Testing.Extensions.CodeCoverage`, and this
> PR now follows that instead.

## The problem

`xunit.v3` 4.0.0 removed the VSTest bridge, so the CI unit-test step's
`dotnet test --collect:"XPlat Code Coverage"` now fails outright on the .NET 10
SDK:

```text
error : Testing with VSTest target is no longer supported by Microsoft.Testing.Platform
on .NET 10 SDK and later. If you use dotnet test, you should opt-in to the new
dotnet test experience.
```

That is what #545 and #546 have been red on, and it blocks every later bump until
the runner moves.

## The fix, per WORKFLOW.md D1.6

| Change | Why |
| --- | --- |
| `global.json` with `{"test":{"runner":"Microsoft.Testing.Platform"}}` | opts into the native MTP runner. No `sdk` section, so SDK resolution and roll-forward are untouched. |
| drop `xunit.runner.visualstudio` | the VSTest adapter MTP replaces |
| `coverlet.collector` -> `Microsoft.Testing.Extensions.CodeCoverage` 18.9.0 | coverlet's VSTest data collector is ignored under MTP without failing |
| CI step -> `dotnet test --coverage --coverage-output-format cobertura --results-directory ./coverage`, then prefix each report to `coverage-<guid>.cobertura.xml` | matches the hub's `validate-task.yml` byte for byte |

Three details are load-bearing, and none of them reds the job on its own:

- **The 18.9.0 floor.** Below 18.1.0 the extension is built against
  Microsoft.Testing.Platform 1.x and throws `TypeLoadException` against the 2.x
  platform xunit.v3 4.0.0 carries. It then runs **zero tests** and still writes a
  well-formed Cobertura file reporting full coverage.
- **`--coverage-output` stays unset.** Pinning one filename would give every test
  project in a solution the same path, and the last to finish would overwrite the
  rest.
- **The prefix rename.** The default `<guid>.cobertura.xml` that the unset flag
  produces is a name codecov-cli's finder does not match (its patterns are
  `*coverage*.*` and an exact `cobertura.xml`), so an unprefixed report uploads
  nothing while the step still exits green.

Package bumps the runner change unblocks: AwesomeAssertions 9.5.0 -> 9.6.0,
xunit.analyzers 1.27.0 -> 2.0.0, xunit.v3 3.2.2 -> 4.0.0.
`Microsoft.NET.Test.Sdk` stays at 18.9.0 (already current).

`.gitignore` gains the hub's dotnet coverage block verbatim. The output was
untracked and unignored, so a blanket `git add -A` after a local coverage run
would have staged it.

## Verification

Against the real invocation, not the documented one:

- 21 tests **ran** and passed, which is the check that matters given the
  zero-test failure mode above.
- Resolved graph (from `obj/project.assets.json`, not the csproj text):
  `Microsoft.Testing.Extensions.CodeCoverage/18.9.0`,
  `Microsoft.Testing.Platform/2.3.3`, `xunit.v3/4.0.0` with the `mtp-v2` variants.
  No coverlet, no `xunit.runner.visualstudio`.
- The run wrote `bbfde807-....cobertura.xml` and the prefix step renamed it to
  `coverage-bbfde807-....cobertura.xml`, confirming the rename is genuinely
  needed rather than defensive.
- `git check-ignore` covers both filename shapes;
  `git ls-files -z | xargs -0 git check-ignore -v` is empty.
- `validate-task.yml` is the only `dotnet test` caller; `publish-release.yml` and
  `test-pull-request.yml` both reach it via `uses:`, so the publish gate and the
  PR gate move together. No `--collect` survives anywhere.
- Build, CSharpier, `dotnet format style --verify-no-changes`,
  editorconfig-checker, actionlint, markdownlint and cspell all clean.

**One thing worth knowing:** the reported coverage number moves, because the
engine does. Line rate goes from 0.59 under coverlet to 0.26 here, with
lines-valid 1350 -> 3143, since this engine instruments more of the graph. It
cannot gate anything: `codecov.yml` sets `informational: true` on both project
and patch, and the only ruleset-required check is
`Check pull request workflow status job`.

## Notes

- Dependabot dual-targets `develop` and `main`, so #546 (the `main` copy) stays
  blocked until this reaches `main` via the promotion PR. `main`'s tree is not
  broken in the meantime, it just cannot take the bump.
- The fleet audit flags this repo's local `validate-task.yml` as `hub-only`.
  Now that ptr727/ProjectTemplate#1111 has landed MTP support in the hub's
  reusable workflow, that migration is unblocked, but it is a separate interface
  change covering five workflow files and belongs in its own PR rather than here.
