### PR TITLE
Use the backslash hard break in the Docker Hub overview

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -4,7 +4,7 @@ Docker images for Network Optix Nx Witness and OEM-branded VMS products.
 
 ## License
 
-Licensed under the [MIT License](https://github.com/ptr727/NxWitness/blob/main/LICENSE)  
+Licensed under the [MIT License](https://github.com/ptr727/NxWitness/blob/main/LICENSE)\
 ![GitHub License](https://img.shields.io/github/license/ptr727/NxWitness)
 
 ## Project


### PR DESCRIPTION
One line. `Docker/README.md` ended the license line with two trailing spaces to force the break before the badge; the fleet rule is a trailing backslash.

The reason is practical rather than stylistic: two trailing spaces are invisible in a diff and in an editor, and any tool that trims trailing whitespace silently joins the two lines into one. The backslash survives that.

Swept the repo's own Markdown, this was the only occurrence. The carried `.github/skills/` tree is excluded as hub content.

## Why this is a separate PR

Qodo raised it on the promotion PR (#556), so the fix already exists there. Landing the identical change on `develop` too, so the two branches stay content-identical through the promotion.

The alternative was to fix it only on `main` via the promotion and mirror it back afterwards. That is the main-only drift this repo's branching rule exists to prevent, and the promotion PR's own claim is that its tree is byte-identical to `develop`, which a one-sided fix would falsify. Cheaper to keep them converged than to owe a back-merge.