### PR TITLE
Mirror the promotion PR's documentation fixes onto develop

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -4,9 +4,21 @@ Docker images for Network Optix Nx Witness and OEM-branded VMS products.
 
 ## License
 
-Licensed under the [MIT License](https://github.com/ptr727/NxWitness/blob/main/LICENSE)\
-![GitHub License](https://img.shields.io/github/license/ptr727/NxWitness)
+Licensed under the [MIT License][license-link]\
+![GitHub License][license-shield]
 
 ## Project
 
-Refer to the [GitHub NxWitness](https://github.com/ptr727/NxWitness/) project for usage and details.
+Refer to the [GitHub NxWitness][github-link] project for usage and details.
+
+<!-- Shields -->
+
+[license-shield]: https://img.shields.io/github/license/ptr727/NxWitness
+
+<!-- Distribution -->
+
+[github-link]: https://github.com/ptr727/NxWitness/
+
+<!-- External -->
+
+[license-link]: https://github.com/ptr727/NxWitness/blob/main/LICENSE

--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ services:
 - [`CreateMatrix`][create-matrix] is used to update available product versions, and to create Docker files for all product permutations.
 - [`Version.json`][version-json] is updated using the mediaserver [Releases JSON API][nxwitnessreleases-link] and [Packages API][packages-link].
 - The logic follows the same pattern as used by the [Nx Open][releaseinfo-link] desktop client logic.
-- The "released" status of a build follows the same method Nx uses in [`isBuildPublished()`][isbuildpublished-link]. Both `release_date` and `release_delivery_days` from the [Releases JSON API][nxwitnessreleases-link] must be greater than `0`.
+- The "released" status of a build follows the same method Nx uses in [`isBuildPublished()`][isbuildpublished-link]. From the [Releases JSON API][nxwitnessreleases-link], `release_date` must be greater than `0` and `release_delivery_days` must be `0` or greater.
 - [`Matrix.json`][matrix-json] is created from the `Version.json` file and is used during pipeline builds using a [Matrix][matrix-link] strategy.
 - Automated builds use [GitHub Actions][github-actions-docs-link]:
   - Pull requests run unit tests, and a fast representative amd64 smoke build of `NxMeta` and `NxMeta-LSIO` ([`test-pull-request.yml`][test-pull-request-workflow]). The smoke build is gated on a change under `Docker/`, or to [`Matrix.json`][matrix-json] or [`Version.json`][version-json]. A version or matrix change is covered rather than skipped. The full matrix is not built on every PR.

--- a/README.md
+++ b/README.md
@@ -299,13 +299,15 @@ Images are tagged as follows:
 - `rc`: Latest RC version, e.g. `docker pull docker.io/ptr727/nxmeta:rc`.
 - `beta`: Latest Beta version, e.g. `docker pull docker.io/ptr727/nxmeta:beta`
 - `develop`: Builds created from the develop branch, e.g. `docker pull docker.io/ptr727/nxmeta:develop`.
+- `develop-stable`: The develop branch's stable build, e.g. `docker pull docker.io/ptr727/nxmeta:develop-stable`.
+- `develop-[version]`: A develop build at a specific version, e.g. `docker pull docker.io/ptr727/nxmeta:develop-6.1.3.43301`.
 - `[version]`: Release version number, e.g. `docker pull docker.io/ptr727/nxmeta:5.2.2.37996`.
 
 Notes:
 
 - `latest` and `stable` may be the same version if all builds are released builds.
 - `rc` and `beta` tags are only built when RC and Beta builds are published by Nx, and may be older than current `latest` or `stable` builds.
-- Images are published once a week on a schedule (and on-demand via manual trigger), picking up the latest upstream Ubuntu updates and newly released Nx product versions. A single scheduled run publishes both the `main` tags (`latest`, `stable`, version numbers) and the `develop` tags. Merging code or dependency updates does not republish images, so the published images only change when there is an actual content change.
+- One publish run covers one branch. The weekly schedule rebuilds `main`, picking up the latest upstream Ubuntu updates, and a push to `main` that changes `Make/Matrix.json` publishes immediately so a newly released Nx version ships without waiting for the schedule. The `develop` tags are published by starting the publisher manually from `develop`. Merging code or dependency updates does not republish images, so the published images only change when there is an actual content change.
 - See [Build Process][build-process] for more details.
 
 ## Configuration
@@ -466,7 +468,7 @@ services:
 - [`Matrix.json`][matrix-json] is created from the `Version.json` file and is used during pipeline builds using a [Matrix][matrix-link] strategy.
 - Automated builds use [GitHub Actions][github-actions-docs-link]:
   - Pull requests run unit tests, and a fast representative amd64 smoke build of `NxMeta` and `NxMeta-LSIO` ([`test-pull-request.yml`][test-pull-request-workflow]). The smoke build is gated on a change under `Docker/`, or to [`Matrix.json`][matrix-json] or [`Version.json`][version-json], so a version or matrix change is covered rather than skipped. The full matrix is not built on every PR.
-  - Publishing happens only on a weekly schedule or manual trigger ([`publish-release.yml`][publish-release-workflow]), which builds and pushes the full matrix for both the `main` and `develop` branches. Merges to `main`/`develop` (including auto-merged Dependabot and codegen updates) do not publish; the next scheduled run picks them up.
+  - Publishing runs on one branch at a time ([`publish-release.yml`][publish-release-workflow]): the weekly schedule and a `Make/Matrix.json` push both publish `main`, and a manual dispatch publishes whichever branch it is started from. Merges to `main`/`develop` (including auto-merged Dependabot and codegen updates) do not publish; the next scheduled run, or a dispatch for `develop`, picks them up.
 - Version history is maintained and used by `CreateMatrix` such that generic tags, e.g. `latest`, will never result in a lesser version number, i.e. break-fix-forward only, see [Issue #62][issue-62-link] for details on Nx re-publishing "released" builds using an older version breaking already upgraded systems.
 
 **Local testing**:

--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ services:
   - Pull requests run unit tests, and a fast representative amd64 smoke build of `NxMeta` and `NxMeta-LSIO` ([`test-pull-request.yml`][test-pull-request-workflow]). The smoke build is gated on a change under `Docker/`, or to [`Matrix.json`][matrix-json] or [`Version.json`][version-json]. A version or matrix change is covered rather than skipped. The full matrix is not built on every PR.
   - Publishing runs on one branch at a time ([`publish-release.yml`][publish-release-workflow]). The weekly schedule publishes `main`. A manual dispatch publishes whichever branch it is started from, which is how `develop` is published.
   - A push to `main` that changes [`Matrix.json`][matrix-json] also publishes `main`, but only when the codegen App or Dependabot made it. A push by a person does not publish.
-  - Any other merge to `main` or `develop` does not publish. The next scheduled run picks it up, or a dispatch for `develop`.
+  - Any other merge does not publish. A merge to `main` ships on the next weekly run, and a merge to `develop` ships only when someone dispatches the publisher from `develop`.
 - Version history is maintained and used by `CreateMatrix` such that generic tags, e.g. `latest`, will never result in a lesser version number, i.e. break-fix-forward only, see [Issue #62][issue-62-link] for details on Nx re-publishing "released" builds using an older version breaking already upgraded systems.
 
 **Local testing**:

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Notes:
 - `latest` and `stable` may be the same version if all builds are released builds.
 - `rc` and `beta` tags are only built when Nx publishes RC and Beta builds. They may be older than the current `latest` or `stable` builds.
 - One publish run covers one branch. The weekly schedule rebuilds `main` and picks up the latest upstream Ubuntu updates.
-- A push to `main` changing `Make/Matrix.json` publishes at once, so a new Nx version ships without waiting for the schedule. Only a push made by the codegen App triggers this, so editing the pin by hand does not publish.
+- A push to `main` changing `Make/Matrix.json` publishes at once, so a new Nx version ships without waiting for the schedule. Only a push by the codegen App or Dependabot triggers this. A push by a person does not publish.
 - The `develop` tags are published by starting the publisher manually from `develop`.
 - Merging code or dependency updates does not republish images. The published images change only when their content changes.
 - See [Build Process][build-process] for more details.
@@ -470,9 +470,10 @@ services:
 - The "released" status of a build follows the same method Nx uses in [`isBuildPublished()`][isbuildpublished-link]. Both `release_date` and `release_delivery_days` from the [Releases JSON API][nxwitnessreleases-link] must be greater than `0`.
 - [`Matrix.json`][matrix-json] is created from the `Version.json` file and is used during pipeline builds using a [Matrix][matrix-link] strategy.
 - Automated builds use [GitHub Actions][github-actions-docs-link]:
-  - Pull requests run unit tests, and a fast representative amd64 smoke build of `NxMeta` and `NxMeta-LSIO` ([`test-pull-request.yml`][test-pull-request-workflow]). The smoke build is gated on a change under `Docker/`, or to [`Matrix.json`][matrix-json] or [`Version.json`][version-json], so a version or matrix change is covered rather than skipped. The full matrix is not built on every PR.
-  - Publishing runs on one branch at a time ([`publish-release.yml`][publish-release-workflow]). The weekly schedule and a codegen `Make/Matrix.json` push both publish `main`. A manual dispatch publishes whichever branch it is started from.
-  - Merges to `main` or `develop`, including auto-merged Dependabot and codegen updates, do not publish. The next scheduled run picks them up, or a dispatch for `develop`.
+  - Pull requests run unit tests, and a fast representative amd64 smoke build of `NxMeta` and `NxMeta-LSIO` ([`test-pull-request.yml`][test-pull-request-workflow]). The smoke build is gated on a change under `Docker/`, or to [`Matrix.json`][matrix-json] or [`Version.json`][version-json]. A version or matrix change is covered rather than skipped. The full matrix is not built on every PR.
+  - Publishing runs on one branch at a time ([`publish-release.yml`][publish-release-workflow]). The weekly schedule publishes `main`. A manual dispatch publishes whichever branch it is started from, which is how `develop` is published.
+  - A push to `main` that changes [`Matrix.json`][matrix-json] also publishes `main`, but only when the codegen App or Dependabot made it. A push by a person does not publish.
+  - Any other merge to `main` or `develop` does not publish. The next scheduled run picks it up, or a dispatch for `develop`.
 - Version history is maintained and used by `CreateMatrix` such that generic tags, e.g. `latest`, will never result in a lesser version number, i.e. break-fix-forward only, see [Issue #62][issue-62-link] for details on Nx re-publishing "released" builds using an older version breaking already upgraded systems.
 
 **Local testing**:

--- a/README.md
+++ b/README.md
@@ -306,8 +306,11 @@ Images are tagged as follows:
 Notes:
 
 - `latest` and `stable` may be the same version if all builds are released builds.
-- `rc` and `beta` tags are only built when RC and Beta builds are published by Nx, and may be older than current `latest` or `stable` builds.
-- One publish run covers one branch. The weekly schedule rebuilds `main`, picking up the latest upstream Ubuntu updates, and a push to `main` that changes `Make/Matrix.json` publishes immediately so a newly released Nx version ships without waiting for the schedule. The `develop` tags are published by starting the publisher manually from `develop`. Merging code or dependency updates does not republish images, so the published images only change when there is an actual content change.
+- `rc` and `beta` tags are only built when Nx publishes RC and Beta builds. They may be older than the current `latest` or `stable` builds.
+- One publish run covers one branch. The weekly schedule rebuilds `main` and picks up the latest upstream Ubuntu updates.
+- A push to `main` changing `Make/Matrix.json` publishes at once, so a new Nx version ships without waiting for the schedule. Only a push made by the codegen App triggers this, so editing the pin by hand does not publish.
+- The `develop` tags are published by starting the publisher manually from `develop`.
+- Merging code or dependency updates does not republish images. The published images change only when their content changes.
 - See [Build Process][build-process] for more details.
 
 ## Configuration
@@ -464,11 +467,12 @@ services:
 - [`CreateMatrix`][create-matrix] is used to update available product versions, and to create Docker files for all product permutations.
 - [`Version.json`][version-json] is updated using the mediaserver [Releases JSON API][nxwitnessreleases-link] and [Packages API][packages-link].
 - The logic follows the same pattern as used by the [Nx Open][releaseinfo-link] desktop client logic.
-- The "released" status of a build follows the same method as Nx uses in [`isBuildPublished()`][isbuildpublished-link] where `release_date` and `release_delivery_days` from the [Releases JSON API][nxwitnessreleases-link] must be greater than `0`
+- The "released" status of a build follows the same method Nx uses in [`isBuildPublished()`][isbuildpublished-link]. Both `release_date` and `release_delivery_days` from the [Releases JSON API][nxwitnessreleases-link] must be greater than `0`.
 - [`Matrix.json`][matrix-json] is created from the `Version.json` file and is used during pipeline builds using a [Matrix][matrix-link] strategy.
 - Automated builds use [GitHub Actions][github-actions-docs-link]:
   - Pull requests run unit tests, and a fast representative amd64 smoke build of `NxMeta` and `NxMeta-LSIO` ([`test-pull-request.yml`][test-pull-request-workflow]). The smoke build is gated on a change under `Docker/`, or to [`Matrix.json`][matrix-json] or [`Version.json`][version-json], so a version or matrix change is covered rather than skipped. The full matrix is not built on every PR.
-  - Publishing runs on one branch at a time ([`publish-release.yml`][publish-release-workflow]): the weekly schedule and a `Make/Matrix.json` push both publish `main`, and a manual dispatch publishes whichever branch it is started from. Merges to `main`/`develop` (including auto-merged Dependabot and codegen updates) do not publish; the next scheduled run, or a dispatch for `develop`, picks them up.
+  - Publishing runs on one branch at a time ([`publish-release.yml`][publish-release-workflow]). The weekly schedule and a codegen `Make/Matrix.json` push both publish `main`. A manual dispatch publishes whichever branch it is started from.
+  - Merges to `main` or `develop`, including auto-merged Dependabot and codegen updates, do not publish. The next scheduled run picks them up, or a dispatch for `develop`.
 - Version history is maintained and used by `CreateMatrix` such that generic tags, e.g. `latest`, will never result in a lesser version number, i.e. break-fix-forward only, see [Issue #62][issue-62-link] for details on Nx re-publishing "released" builds using an older version breaking already upgraded systems.
 
 **Local testing**:


### PR DESCRIPTION
Two documentation fixes raised on the promotion PR (#556), landed on `develop` as well so the two branches stay content-identical through the promotion.

## Convert the Docker Hub overview to reference-style links

The carried `comment-and-doc-style` contract requires reference-style links in every Markdown file except a closed list of four that are read one section at a time rather than end to end: `AGENTS.md`, `GOVERNANCE.md`, `OPERATIONS.md`, and `.github/copilot-instructions.md`. `Docker/README.md` is not on it.

Three definitions, grouped under the declared `Shields`, `Distribution` and `External` headers and sorted within each. Docker Hub resolves reference-style links when it renders the overview, so the published page is unchanged.

> An earlier revision of this description named the exception list as `AGENTS.md`, `GOVERNANCE.md`, `CODESTYLE.md`, `WORKFLOW.md`. That was wrong, and the reviewer caught it. The list above is what `comment-and-doc-style/references/markdown-links.md` actually states. The fix to `Docker/README.md` is unaffected, since that file is off the list either way, but the justification named the wrong files.

## Correct the publish contract and tag list

The more substantive of the two. The README described a publish model this repo does not run: it said a single scheduled run publishes both the `main` tags and the `develop` tags.

`publish-release.yml` is a triggered-Docker publisher, and its own header states one run covers one branch. The weekly schedule rebuilds `main`. A push to `main` changing `Make/Matrix.json` publishes immediately, so a newly released Nx version ships without waiting a week. A dispatch publishes whichever branch it is started from. **Nothing publishes `develop` on a schedule**, so a reader waiting for the weekly run to refresh `:develop` would have waited indefinitely.

The `Make/Matrix.json` push trigger was missing from both places entirely, and it is the one that matters most to a consumer.

The tag list also omitted `develop-stable` and `develop-[version]`, both of which `Make/Matrix.json` produces today.

Verified against the workflow's trigger block and header, and against the tag set derived from `Make/Matrix.json`.

## Why these are mirrored rather than left to the promotion

#556's stated property is that its tree is byte-identical to `develop`. A fix landed only on `main` through the promotion would falsify that and create the main-only drift this repo's own branching rule exists to prevent. Cheaper to keep the branches converged than to owe a back-merge.

**Merge this before #556**, or `develop` lands behind again.

## Out of scope, and measured

Getting the exception list right surfaced a real gap that is not this PR's to close. `CODESTYLE.md` carries 16 inline links and `WORKFLOW.md` carries 12, and neither is on the exempt list, so both violate the rule they carry:

| File | Inline | Reference | Status |
| --- | --- | --- | --- |
| `AGENTS.md` | 8 | 0 | exempt |
| `GOVERNANCE.md` | 29 | 0 | exempt |
| `OPERATIONS.md` | 5 | 0 | exempt |
| `.github/copilot-instructions.md` | 15 | 0 | exempt |
| `CODESTYLE.md` | 16 | 0 | **violates** |
| `WORKFLOW.md` | 12 | 0 | **violates** |
| `ARCHITECTURE.md` | 0 | 7 | conforms |
| `README.md` | 0 | 233 | conforms |
| `HISTORY.md` | 0 | 12 | conforms |
| `Docker/README.md` | 0 | 3 | conforms after this PR |

Both are carried files, and the hub's own copies have the same inline links, so converting them here would diverge from the canonical rather than fix anything fleet-wide. Reported to ptr727/ProjectTemplate#1131 instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated license and project links with clearer, centralized references.
  * Expanded Docker publishing documentation to explain branch-specific image tags and publishing behavior.
  * Documented `develop-stable` and version-specific `develop-[version]` tags.
  * Clarified which workflows publish images and how manually selected branches are handled.
  * Clarified release eligibility requirements for builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->